### PR TITLE
fix toolchain to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
 
       - name: Cache Go build
         uses: actions/cache@v4
@@ -28,8 +28,8 @@ jobs:
 
       - name: Lint
         run: |
-          go install mvdan.cc/gofumpt@latest
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install mvdan.cc/gofumpt@v0.6.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
           make fmt
           make lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Auto-generated from all feature plans. Last updated: 2025-10-05
 
 ## Active Technologies
-- Go 1.22 (gofmt + gofumpt enforced) + Cobra CLI, Helm SDK, k3s install scripts, system-upgrade-controller CRDs, OpenTelemetry SDK (001-single-k8s-app-ctl)
+- Go 1.24 (gofmt + gofumpt enforced) + Cobra CLI, Helm SDK, k3s install scripts, system-upgrade-controller CRDs, OpenTelemetry SDK (001-single-k8s-app-ctl)
 
 ## Project Structure
 ```
@@ -21,10 +21,10 @@ test/                # unit, integration (envtest/kind), and e2e suites
 - Benchmarks: `go test -bench . ./pkg/...`
 
 ## Code Style
-Go 1.22 (gofmt + gofumpt enforced): use wrapped errors, keep exported function docs concise, prefer context-aware operations, follow noun-verb CLI naming.
+Go 1.24 (gofmt + gofumpt enforced): use wrapped errors, keep exported function docs concise, prefer context-aware operations, follow noun-verb CLI naming.
 
 ## Recent Changes
-- 001-single-k8s-app-ctl: Added Go 1.22 (gofmt + gofumpt enforced) + Cobra CLI, Helm SDK, k3s install scripts, system-upgrade-controller CRDs, OpenTelemetry SDK
+- 001-single-k8s-app-ctl: Added Go 1.24 (gofmt + gofumpt enforced) + Cobra CLI, Helm SDK, k3s install scripts, system-upgrade-controller CRDs, OpenTelemetry SDK
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ GO ?= go
 GOCACHE ?= $(CURDIR)/.gocache
 GOFLAGS ?=
 
+GO_BIN_DIR := $(strip $(shell $(GO) env GOBIN))
+ifeq ($(GO_BIN_DIR),)
+GO_BIN_DIR := $(strip $(shell $(GO) env GOPATH))/bin
+endif
+GOFUMPT := $(GO_BIN_DIR)/gofumpt
+GOLANGCI_LINT := $(GO_BIN_DIR)/golangci-lint
+
 PACKAGES = ./...
 FMT_DIRS = cmd internal pkg test
 
@@ -10,19 +17,19 @@ FMT_DIRS = cmd internal pkg test
 fmt:
 	@echo "==> Running go fmt"
 	@GOCACHE=$(GOCACHE) $(GO) fmt ./...
-	@if command -v gofumpt >/dev/null 2>&1; then \
+	@if [ -x "$(GOFUMPT)" ]; then \
 		echo "==> Running gofumpt"; \
-		gofumpt -w $(FMT_DIRS); \
+		"$(GOFUMPT)" -w $(FMT_DIRS); \
 	else \
-		echo "WARN: gofumpt not installed; install via '$(GO) install mvdan.cc/gofumpt@latest'"; \
+		echo "WARN: gofumpt not installed; install via '$(GO) install mvdan.cc/gofumpt@v0.6.0'"; \
 	fi
 
 lint:
-	@if command -v golangci-lint >/dev/null 2>&1; then \
+	@if [ -x "$(GOLANGCI_LINT)" ]; then \
 		echo "==> Running golangci-lint"; \
-		GOCACHE=$(GOCACHE) golangci-lint run ./...; \
+		GOCACHE=$(GOCACHE) "$(GOLANGCI_LINT)" run --timeout=5m ./...; \
 	else \
-		echo "WARN: golangci-lint not installed; install via '$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest'"; \
+		echo "WARN: golangci-lint not installed; install via '$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2'"; \
 	fi
 
 TEST_FLAGS ?=

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -1,9 +1,9 @@
 # chainctl Development Environment
 
-This project targets Go 1.22 and Linux hosts (Ubuntu 22.04+, RHEL 9+) for execution. Development requires the following:
+This project targets Go 1.24 and Linux hosts (Ubuntu 22.04+, RHEL 9+) for execution. Development requires the following:
 
 ## Tooling
-- Go 1.22 (install via `asdf` or `goenv` to match CI).
+- Go 1.24 (install via `asdf` or `goenv` to match CI).
 - Docker + KIND and/or k3s for integration/e2e testing.
 - `golangci-lint` and `gofumpt` (installed via `go install`).
 - Helm 3, kubectl, and system-upgrade-controller binaries pinned per constitution guardrails.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/dobrovols/chainctl
 
 go 1.24.0
 
+toolchain go1.24.7
+
 require (
 	github.com/spf13/cobra v1.10.1
 	go.opentelemetry.io/otel v1.38.0

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // Error sentinel values for bundle integrity validation.

--- a/specs/001-single-k8s-app-ctl/plan.md
+++ b/specs/001-single-k8s-app-ctl/plan.md
@@ -30,10 +30,10 @@
 - Phase 3-4: Implementation execution (manual or via tools)
 
 ## Summary
-Deliver a Go 1.22 single binary `chainctl` that can bootstrap or reuse k3s clusters on Ubuntu/RHEL, install and upgrade the Helm-based micro-services stack, orchestrate k3s upgrades via system-upgrade-controller, operate with removable-media air-gapped bundles, and manage node joins through scoped tokens while enforcing encrypted configuration inputs and observability budgets.
+Deliver a Go 1.24 single binary `chainctl` that can bootstrap or reuse k3s clusters on Ubuntu/RHEL, install and upgrade the Helm-based micro-services stack, orchestrate k3s upgrades via system-upgrade-controller, operate with removable-media air-gapped bundles, and manage node joins through scoped tokens while enforcing encrypted configuration inputs and observability budgets.
 
 ## Technical Context
-**Language/Version**: Go 1.22 (gofmt + gofumpt enforced)  
+**Language/Version**: Go 1.24 (gofmt + gofumpt enforced)  
 **Primary Dependencies**: Cobra CLI, Helm SDK, k3s install scripts, system-upgrade-controller CRDs, OpenTelemetry SDK  
 **Storage**: local-path StorageClass (k3s default), filesystem bundle mount under `/opt/chainctl/bundles`  
 **Testing**: `go test`, `ginkgo`, controller-runtime envtest, kind-based e2e smoke suites  
@@ -120,7 +120,7 @@ test/
 1. Data shapes for installation profiles, bundle manifests, tokens, upgrade plans, and telemetry envelopes defined in `data-model.md` to anchor Go struct design and validation rules.
 2. CLI command contracts authored for install, app upgrade, cluster upgrade, node join, token create, and encrypt-values flows, capturing flags, outputs, exit codes, and observability expectations.
 3. Quickstart walkthrough documents bootstrap, upgrade, node join, and cluster upgrade scenarios for both online and air-gapped environments.
-4. `.specify/scripts/bash/update-agent-context.sh codex` executed to refresh shared agent guidance with new technologies (Go 1.22, Helm SDK, system-upgrade-controller, OpenTelemetry, envtest, kind).
+4. `.specify/scripts/bash/update-agent-context.sh codex` executed to refresh shared agent guidance with new technologies (Go 1.24, Helm SDK, system-upgrade-controller, OpenTelemetry, envtest, kind).
 
 **Outputs**:
 - `/Users/dobrovolsky/sources/golang/chainctl/specs/001-single-k8s-app-ctl/data-model.md`
@@ -157,4 +157,3 @@ test/
 - [ ] Phase 3: Tasks generated (/tasks command)
 - [ ] Phase 4: Implementation complete
 - [ ] Phase 5: Validation passed
-

--- a/specs/001-single-k8s-app-ctl/tasks.md
+++ b/specs/001-single-k8s-app-ctl/tasks.md
@@ -16,7 +16,7 @@
 - [x] T001 Establish Go workspace structure: create `cmd/chainctl`, `pkg/{bootstrap,helm,upgrade,bundle,secrets,tokens,telemetry}`, `internal/{validation,config,kubeclient}`, and `test/{unit,integration,e2e}` with placeholder README.md files.
 - [x] T002 Configure tooling: update `go.mod`, add `tools.go` if needed, wire `Makefile` targets for `gofmt`, `gofumpt`, `golangci-lint`, `go test`, `go test -bench`, and add CI jobs.
 - [x] T003 [P] Vendor third-party assets: pin Helm SDK, controller-runtime/envtest, OpenTelemetry, Cobra; update `go.sum` via `go mod tidy`.
-- [x] T004 Document dev environment expectations in `docs/development/environment.md` (Go 1.22, asdf/goenv, bundle mount paths).
+- [x] T004 Document dev environment expectations in `docs/development/environment.md` (Go 1.24, asdf/goenv, bundle mount paths).
 
 ## Phase 3.2: Tests First (TDD)
 - [x] T005 [P] Write unit tests for bundle handling in `test/unit/bundle_tarball_test.go` covering checksum failures and manifest parsing.


### PR DESCRIPTION
Align project and CI toolchain with Go 1.24 so Kubernetes 0.34 deps build cleanly, including go.mod, workflow setup, and developer docs.

Update lint/install steps to pin gofumpt@v0.6.0 and golangci-lint@v1.62.2, and drive those binaries from the configured GO toolchain in the Makefile.

Fix bundle manifest helpers to import gopkg.in/yaml.v3 explicitly for golangci-lint type checking.