### PR TITLE
feat: add declarative configuration support and coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Auto-generated from all feature plans. Last updated: 2025-10-05
 - Local filesystem JSON state file under user config directory (002-oci-helm-state)
 - Go 1.24 + `spf13/cobra`, `helm.sh/helm/v3`, existing `pkg/telemetry`, `pkg/bootstrap`, `pkg/helm`, OpenTelemetry exporters (003-logging)
 - N/A (logs streamed to stdout/stderr for aggregation) (003-logging)
+- Go 1.24 + `spf13/cobra`, `helm.sh/helm/v3`, internal `pkg/state`, `pkg/telemetry`, `internal/config`, YAML parsing via `gopkg.in/yaml.v3` (004-declarative-config-file)
+- Local filesystem YAML files under repo or XDG config directories (read-only at runtime) (004-declarative-config-file)
 
 ## Project Structure
 ```
@@ -28,9 +30,9 @@ test/                # unit, integration (envtest/kind), and e2e suites
 Go 1.24 (gofmt + gofumpt enforced): use wrapped errors, keep exported function docs concise, prefer context-aware operations, follow noun-verb CLI naming.
 
 ## Recent Changes
+- 004-declarative-config-file: Added Go 1.24 + `spf13/cobra`, `helm.sh/helm/v3`, internal `pkg/state`, `pkg/telemetry`, `internal/config`, YAML parsing via `gopkg.in/yaml.v3`
 - 003-logging: Added Go 1.24 + `spf13/cobra`, `helm.sh/helm/v3`, existing `pkg/telemetry`, `pkg/bootstrap`, `pkg/helm`, OpenTelemetry exporters
 - 003-logging: Added Go 1.24 + `spf13/cobra`, `helm.sh/helm/v3`, existing `pkg/telemetry`, `pkg/bootstrap`, `pkg/helm`, OpenTelemetry exporters
-- 002-oci-helm-state: Added CLI support for OCI chart references (`--chart oci://...`), mutually exclusive with `--bundle-path`; persisted state file with overrides (`--state-file`, `--state-file-name`). Go 1.24 + Cobra CLI (`spf13/cobra`), Helm SDK (`helm.sh/helm/v3`) leveraged alongside existing `pkg/bundle`, `pkg/helm`, `pkg/telemetry`.
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- feat: support declarative flag configuration via `chainctl.yaml`, including discovery precedence, profile merging, telemetry/log summaries, and CLI documentation updates.
 - feat: add structured logging across cluster/app workflows with sanitized helm/bootstrap command telemetry.
 - docs: update quickstart, runbooks, and examples for centralized log ingestion.
 - feat: add OpenTelemetry wiring with configurable exporters.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ chainctl is a single-binary Go CLI for installing, upgrading, and operating a Ku
 - **Node onboarding**: `chainctl node token` / `chainctl node join` manage scoped pre-shared tokens for multi-node scaling.
 - **Air-gapped ready**: Installer reads bundles from removable media tarballs with checksum validation.
 - **Security**: Encrypted values files handled via AES-256-GCM; OTEL exporters support hashed cluster IDs.
+- **Declarative configuration**: Supply `chainctl.yaml` to preload flag values and reusable profiles. Autodiscovery searches `--config`, `CHAINCTL_CONFIG`, the working directory, XDG config home, then `$HOME/.config/chainctl/config.yaml`. Summaries show each flag's effective value and source (default, profile, command, runtime).
 
 ## Quickstart
 See [`specs/001-single-k8s-app-ctl/quickstart.md`](specs/001-single-k8s-app-ctl/quickstart.md) for full instructions.
@@ -16,6 +17,7 @@ See [`specs/001-single-k8s-app-ctl/quickstart.md`](specs/001-single-k8s-app-ctl/
 Basic bootstrap (online):
 ```bash
 chainctl cluster install \
+  --config chainctl.yaml \
   --bootstrap \
   --values-file /path/to/values.enc \
   --values-passphrase "$CHAINCTL_VALUES_PASSPHRASE"
@@ -44,6 +46,7 @@ chainctl app install \
 Application upgrade with JSON output (OCI chart + state persistence):
 ```bash
 chainctl app upgrade \
+  --config chainctl.yaml \
   --cluster-endpoint https://cluster.local \
   --values-file values.enc \
   --values-passphrase "$CHAINCTL_VALUES_PASSPHRASE" \
@@ -54,6 +57,8 @@ chainctl app upgrade \
   --state-file-name app.json \
   --output json
 ```
+
+Declarative configs may define shared namespaces, bundles, dry-run defaults, and app profiles. Runtime flags always win, and each command prints a summary before execution so operators can verify the merged configuration. Sample YAML and summaries live in [`docs/examples/config/`](docs/examples/config/).
 
 State file defaults to `$XDG_CONFIG_HOME/chainctl/state/app.json` (or `$HOME/.chainctl/state/app.json`). Override with `--state-file` (absolute path) or `--state-file-name` (filename within managed directory). On failures to write state, the deployment remains and the CLI reports the error.
 

--- a/cmd/chainctl/app/action.go
+++ b/cmd/chainctl/app/action.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/dobrovols/chainctl/cmd/chainctl/declarative"
 	"github.com/dobrovols/chainctl/internal/config"
 	internalstate "github.com/dobrovols/chainctl/internal/state"
 	"github.com/dobrovols/chainctl/pkg/bundle"
@@ -109,6 +110,9 @@ func runAppAction(cmd *cobra.Command, options sharedOptions, deps UpgradeDeps, a
 	logger := tel.StructuredLogger()
 	if logger == nil {
 		return fmt.Errorf("structured logger unavailable")
+	}
+	if resolved, ok := declarative.ResolvedInvocationFromContext(cmd); ok {
+		declarative.EmitTelemetry(logger, resolved)
 	}
 
 	workflowStep := workflowStepName(action)

--- a/cmd/chainctl/app/config_flag.go
+++ b/cmd/chainctl/app/config_flag.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/dobrovols/chainctl/cmd/chainctl/declarative"
+)
+
+func markDeclarative(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[declarative.AnnotationEnabled] = "true"
+}

--- a/cmd/chainctl/app/install.go
+++ b/cmd/chainctl/app/install.go
@@ -21,6 +21,7 @@ func NewInstallCommand() *cobra.Command {
 	}
 
 	bindCommonFlags(cmd, &opts)
+	markDeclarative(cmd)
 
 	return cmd
 }

--- a/cmd/chainctl/app/upgrade.go
+++ b/cmd/chainctl/app/upgrade.go
@@ -71,6 +71,7 @@ func NewUpgradeCommand() *cobra.Command {
 	}
 
 	bindCommonFlags(cmd, &opts)
+	markDeclarative(cmd)
 
 	return cmd
 }

--- a/cmd/chainctl/cluster/config_flag.go
+++ b/cmd/chainctl/cluster/config_flag.go
@@ -1,0 +1,14 @@
+package cluster
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/dobrovols/chainctl/cmd/chainctl/declarative"
+)
+
+func markDeclarative(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[declarative.AnnotationEnabled] = "true"
+}

--- a/cmd/chainctl/cluster/install.go
+++ b/cmd/chainctl/cluster/install.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/dobrovols/chainctl/cmd/chainctl/declarative"
 	"github.com/dobrovols/chainctl/internal/config"
 	"github.com/dobrovols/chainctl/internal/validation"
 	"github.com/dobrovols/chainctl/pkg/bootstrap"
@@ -111,6 +112,7 @@ func NewInstallCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Airgapped, "airgapped", false, "Use air-gapped mode (requires --bundle-path)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Run validations without applying changes")
 	cmd.Flags().StringVar(&opts.Output, "output", "text", "Output format: text or json")
+	markDeclarative(cmd)
 
 	return cmd
 }
@@ -161,6 +163,9 @@ func runInstall(cmd *cobra.Command, opts InstallOptions, deps InstallDeps) (err 
 	logger := tel.StructuredLogger()
 	if logger == nil {
 		return fmt.Errorf("structured logger unavailable")
+	}
+	if resolved, ok := declarative.ResolvedInvocationFromContext(cmd); ok {
+		declarative.EmitTelemetry(logger, resolved)
 	}
 	bootstrapHasLogging := false
 	if orch, ok := deps.Bootstrapper.(*bootstrap.Orchestrator); ok {

--- a/cmd/chainctl/cluster/install_internal_test.go
+++ b/cmd/chainctl/cluster/install_internal_test.go
@@ -1,0 +1,74 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dobrovols/chainctl/internal/config"
+	"github.com/dobrovols/chainctl/pkg/bundle"
+)
+
+const (
+	clusterTestValuesFile      = "/tmp/values.enc"
+	clusterTestSecret          = "secret"
+	clusterTestBundleTgz       = "/tmp/bundle.tgz"
+	clusterTestClusterEndpoint = "https://cluster.local"
+)
+
+func TestBuildProfileReuseMode(t *testing.T) {
+	opts := InstallOptions{
+		ClusterEndpoint:  clusterTestClusterEndpoint,
+		ValuesFile:       clusterTestValuesFile,
+		ValuesPassphrase: clusterTestSecret,
+	}
+	profile, err := buildProfile(opts)
+	if err != nil {
+		t.Fatalf("buildProfile: %v", err)
+	}
+	if profile.Mode != config.ModeReuse {
+		t.Fatalf("expected reuse mode, got %s", profile.Mode)
+	}
+	if profile.ClusterEndpoint != opts.ClusterEndpoint {
+		t.Fatalf("expected cluster endpoint to be set, got %s", profile.ClusterEndpoint)
+	}
+}
+
+func TestBuildProfileAirgappedRequiresBundle(t *testing.T) {
+	opts := InstallOptions{
+		Bootstrap:        true,
+		ValuesFile:       clusterTestValuesFile,
+		ValuesPassphrase: clusterTestSecret,
+		Airgapped:        true,
+	}
+	if _, err := buildProfile(opts); err == nil {
+		t.Fatalf("expected bundle path requirement error")
+	}
+	opts.BundlePath = clusterTestBundleTgz
+	profile, err := buildProfile(opts)
+	if err != nil {
+		t.Fatalf("buildProfile with bundle: %v", err)
+	}
+	if !profile.Airgapped || profile.BundlePath == "" {
+		t.Fatalf("expected airgapped profile with bundle path")
+	}
+}
+
+func TestPrepareBundleSkipsWhenNotAirgapped(t *testing.T) {
+	profile := &config.Profile{Airgapped: false}
+	b, err := prepareBundle(profile, InstallOptions{}, InstallDeps{})
+	if err != nil {
+		t.Fatalf("prepareBundle: %v", err)
+	}
+	if b != nil {
+		t.Fatalf("expected nil bundle when not airgapped")
+	}
+}
+
+func TestEmitOutputUnsupportedFormat(t *testing.T) {
+	cmd := &cobra.Command{}
+	err := emitOutput(cmd, &config.Profile{}, &bundle.Bundle{}, false, "yaml")
+	if err != errUnsupportedOutput {
+		t.Fatalf("expected errUnsupportedOutput, got %v", err)
+	}
+}

--- a/cmd/chainctl/declarative/binder.go
+++ b/cmd/chainctl/declarative/binder.go
@@ -1,0 +1,282 @@
+package declarative
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	internalconfig "github.com/dobrovols/chainctl/internal/config"
+	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
+	"github.com/dobrovols/chainctl/pkg/telemetry"
+)
+
+const configFlagName = "config"
+
+// Annotation keys used to mark commands that participate in declarative configuration.
+const (
+	AnnotationEnabled = "declarative-config"
+)
+
+// Manager wires declarative configuration discovery and application into annotated commands.
+type Manager struct {
+	catalog internalconfig.FlagCatalog
+	loader  *internalconfig.Loader
+}
+
+// NewManager constructs a manager for the provided root command.
+func NewManager(root *cobra.Command) *Manager {
+	catalog := internalconfig.NewCobraCatalog(root)
+	return &Manager{
+		catalog: catalog,
+		loader:  internalconfig.NewLoader(catalog),
+	}
+}
+
+// Bind walks the command tree and attaches declarative configuration behaviour to each annotated command.
+func (m *Manager) Bind(root *cobra.Command) {
+	walkCommands(root, func(cmd *cobra.Command) {
+		if cmd.Annotations == nil || strings.ToLower(cmd.Annotations[AnnotationEnabled]) != "true" {
+			return
+		}
+		if cmd.Flags().Lookup(configFlagName) == nil {
+			cmd.Flags().String(configFlagName, "", "Path to declarative configuration file")
+		}
+		existing := cmd.PreRunE
+		cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+			if err := m.apply(cmd); err != nil {
+				return err
+			}
+			if existing != nil {
+				return existing(cmd, args)
+			}
+			return nil
+		}
+	})
+}
+
+func (m *Manager) apply(cmd *cobra.Command) error {
+	flagSet := cmd.Flags()
+	if flagSet == nil {
+		return nil
+	}
+
+	explicitPath, err := flagSet.GetString(configFlagName)
+	if err != nil {
+		return fmt.Errorf("read --config flag: %w", err)
+	}
+
+	var (
+		location internalconfig.LocationResult
+		locErr   error
+	)
+	if strings.TrimSpace(explicitPath) != "" {
+		location, locErr = internalconfig.LocateConfig(explicitPath)
+	} else {
+		location, locErr = internalconfig.LocateConfig("")
+		if errors.Is(locErr, internalconfig.ErrConfigNotFound) {
+			return nil
+		}
+	}
+	if locErr != nil {
+		return locErr
+	}
+
+	runtime, err := collectRuntimeOverrides(cmd)
+	if err != nil {
+		return err
+	}
+
+	profile, err := m.loader.Load(location.Path)
+	if err != nil {
+		return err
+	}
+
+	commandPath := cmd.CommandPath()
+	resolved, err := pkgconfig.ResolveInvocation(profile, commandPath, runtime)
+	if err != nil {
+		return err
+	}
+
+	if err := applyResolvedFlags(cmd, resolved); err != nil {
+		return err
+	}
+
+	storeResolvedInvocation(cmd, resolved)
+
+	outputFormat, _ := flagSet.GetString("output")
+	if outputFormat == "" {
+		outputFormat = pkgconfig.SummaryFormatText
+	} else {
+		outputFormat = strings.ToLower(outputFormat)
+	}
+	if outputFormat != pkgconfig.SummaryFormatText && outputFormat != pkgconfig.SummaryFormatJSON {
+		outputFormat = pkgconfig.SummaryFormatText
+	}
+
+	summary, err := pkgconfig.FormatSummary(resolved, outputFormat)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), summary)
+	return nil
+}
+
+func collectRuntimeOverrides(cmd *cobra.Command) (pkgconfig.FlagSet, error) {
+	runtime := pkgconfig.FlagSet{}
+	var firstErr error
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if !flag.Changed || flag.Name == configFlagName || firstErr != nil {
+			return
+		}
+		switch flag.Value.Type() {
+		case "bool":
+			val, err := cmd.Flags().GetBool(flag.Name)
+			if err != nil {
+				firstErr = err
+				return
+			}
+			runtime[flag.Name] = pkgconfig.FlagValue{Value: val, Source: pkgconfig.ValueSourceRuntime}
+		case "stringSlice", "stringArray":
+			val, err := cmd.Flags().GetStringSlice(flag.Name)
+			if err != nil {
+				firstErr = err
+				return
+			}
+			runtime[flag.Name] = pkgconfig.FlagValue{Value: append([]string(nil), val...), Source: pkgconfig.ValueSourceRuntime}
+		default:
+			val, err := cmd.Flags().GetString(flag.Name)
+			if err != nil {
+				firstErr = err
+				return
+			}
+			runtime[flag.Name] = pkgconfig.FlagValue{Value: val, Source: pkgconfig.ValueSourceRuntime}
+		}
+	})
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	if len(runtime) == 0 {
+		return nil, nil
+	}
+	return runtime, nil
+}
+
+func applyResolvedFlags(cmd *cobra.Command, resolved *pkgconfig.ResolvedInvocation) error {
+	for name, flagValue := range resolved.Flags {
+		if name == configFlagName {
+			continue
+		}
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			resolved.Warnings = append(resolved.Warnings, fmt.Sprintf("flag %q ignored (not recognised by command)", name))
+			continue
+		}
+		var value string
+		switch flag.Value.Type() {
+		case "bool":
+			boolVal, ok := flagValue.Value.(bool)
+			if !ok {
+				return fmt.Errorf("%w: %s expects boolean", internalconfig.ErrInvalidFlagType, name)
+			}
+			if err := cmd.Flags().Set(name, fmt.Sprintf("%t", boolVal)); err != nil {
+				return fmt.Errorf("apply flag %q: %w", name, err)
+			}
+			continue
+		case "stringSlice", "stringArray":
+			slice, err := toStringSlice(flagValue.Value)
+			if err != nil {
+				return fmt.Errorf("%w: %s expects string list", internalconfig.ErrInvalidFlagType, name)
+			}
+			value = strings.Join(slice, ",")
+		default:
+			value = fmt.Sprint(flagValue.Value)
+		}
+		if err := cmd.Flags().Set(name, value); err != nil {
+			return fmt.Errorf("apply flag %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func toStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...), nil
+	case []interface{}:
+		out := make([]string, len(v))
+		for i, item := range v {
+			out[i] = fmt.Sprint(item)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported slice type %T", value)
+	}
+}
+
+func walkCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(child, fn)
+	}
+}
+
+type resolvedContextKey struct{}
+
+func storeResolvedInvocation(cmd *cobra.Command, resolved *pkgconfig.ResolvedInvocation) {
+	if cmd == nil || resolved == nil {
+		return
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd.SetContext(context.WithValue(ctx, resolvedContextKey{}, resolved))
+}
+
+// ResolvedInvocationFromContext retrieves the resolved invocation stored for the command.
+func ResolvedInvocationFromContext(cmd *cobra.Command) (*pkgconfig.ResolvedInvocation, bool) {
+	if cmd == nil {
+		return nil, false
+	}
+	if ctx := cmd.Context(); ctx != nil {
+		if resolved, ok := ctx.Value(resolvedContextKey{}).(*pkgconfig.ResolvedInvocation); ok {
+			return resolved, true
+		}
+	}
+	return nil, false
+}
+
+// EmitTelemetry emits a configuration summary via the provided structured logger.
+func EmitTelemetry(logger telemetry.StructuredLogger, resolved *pkgconfig.ResolvedInvocation) {
+	if logger == nil || resolved == nil {
+		return
+	}
+
+	metadata := map[string]string{
+		"command": resolved.CommandPath,
+	}
+	if resolved.SourcePath != "" {
+		metadata["sourcePath"] = resolved.SourcePath
+	}
+	if len(resolved.Profiles) > 0 {
+		metadata["profiles"] = strings.Join(resolved.Profiles, ",")
+	}
+	if len(resolved.Overrides) > 0 {
+		metadata["overrides"] = strings.Join(resolved.Overrides, ",")
+	}
+	for name, value := range resolved.Flags {
+		metadata["flag."+name] = fmt.Sprint(value.Value)
+		metadata["flag."+name+".source"] = string(value.Source)
+	}
+
+	_ = logger.Emit(telemetry.Entry{
+		Category: telemetry.CategoryConfig,
+		Message:  "declarative configuration resolved",
+		Severity: telemetry.SeverityInfo,
+		Metadata: metadata,
+	})
+}

--- a/cmd/chainctl/declarative/binder_test.go
+++ b/cmd/chainctl/declarative/binder_test.go
@@ -1,0 +1,294 @@
+package declarative
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
+	"github.com/dobrovols/chainctl/pkg/telemetry"
+)
+
+func TestBinderAppliesConfigAndRuntimeOverrides(t *testing.T) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "chainctl.yaml")
+	yaml := `
+defaults:
+  namespace: default-ns
+  roles:
+    - base
+    - 42
+commands:
+  chainctl cluster install:
+    flags:
+      dry-run: "true"
+      output: json
+`
+	if err := os.WriteFile(configPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	root := &cobra.Command{
+		Use: "chainctl",
+	}
+	errBuf := new(bytes.Buffer)
+	root.SetErr(errBuf)
+	root.SetOut(&bytes.Buffer{})
+
+	cluster := &cobra.Command{
+		Use: "cluster",
+	}
+	cluster.SetErr(errBuf)
+	cluster.SetOut(&bytes.Buffer{})
+
+	install := &cobra.Command{
+		Use: "install",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return err
+			}
+			if dryRun {
+				t.Fatalf("expected runtime override to set dry-run=false")
+			}
+
+			namespace, err := cmd.Flags().GetString("namespace")
+			if err != nil {
+				return err
+			}
+			if namespace != "runtime-ns" {
+				t.Fatalf("namespace = %q, want runtime-ns", namespace)
+			}
+
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return err
+			}
+			if output != "json" {
+				t.Fatalf("output = %q, want json from config file", output)
+			}
+
+			roles, err := cmd.Flags().GetStringSlice("roles")
+			if err != nil {
+				return err
+			}
+			expectedRoles := []string{"runtimeA", "runtimeB"}
+			if len(roles) < 2 {
+				t.Fatalf("roles = %#v, want at least two entries", roles)
+			}
+			if !reflect.DeepEqual(roles[len(roles)-2:], expectedRoles) {
+				t.Fatalf("roles tail = %#v, want %#v", roles[len(roles)-2:], expectedRoles)
+			}
+
+			resolved, ok := ResolvedInvocationFromContext(cmd)
+			if !ok {
+				t.Fatalf("expected resolved invocation in context")
+			}
+			if resolved.Flags["namespace"].Source != pkgconfig.ValueSourceRuntime {
+				t.Fatalf("namespace source = %s, want runtime", resolved.Flags["namespace"].Source)
+			}
+			if resolved.Flags["dry-run"].Source != pkgconfig.ValueSourceRuntime {
+				t.Fatalf("dry-run source = %s, want runtime", resolved.Flags["dry-run"].Source)
+			}
+			if resolved.Flags["output"].Source != pkgconfig.ValueSourceCommand {
+				t.Fatalf("output source = %s, want command", resolved.Flags["output"].Source)
+			}
+			if rolesVal, ok := resolved.Flags["roles"]; ok {
+				if !reflect.DeepEqual(rolesVal.Value, expectedRoles) {
+					t.Fatalf("resolved roles value = %#v, want %#v", rolesVal.Value, expectedRoles)
+				}
+			}
+			return nil
+		},
+	}
+	install.Annotations = map[string]string{AnnotationEnabled: "true"}
+	install.SetErr(errBuf)
+	install.SetOut(&bytes.Buffer{})
+
+	install.Flags().String("namespace", "", "")
+	install.Flags().Bool("dry-run", false, "")
+	install.Flags().String("output", "text", "")
+	install.Flags().StringSlice("roles", []string{}, "")
+
+	cluster.AddCommand(install)
+	root.AddCommand(cluster)
+
+	t.Setenv("CHAINCTL_CONFIG", configPath)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	NewManager(root).Bind(root)
+
+	root.SetArgs([]string{
+		"cluster", "install",
+		"--namespace", "runtime-ns",
+		"--dry-run=false",
+		"--roles", "runtimeA",
+		"--roles", "runtimeB",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+
+	summary := errBuf.String()
+	if !strings.Contains(summary, `"commandPath": "chainctl cluster install"`) {
+		t.Fatalf("summary missing command path:\n%s", summary)
+	}
+	if !strings.Contains(summary, `"namespace"`) || !strings.Contains(summary, `"runtime-ns"`) {
+		t.Fatalf("summary missing runtime namespace override:\n%s", summary)
+	}
+	if !strings.Contains(summary, `"roles"`) || !strings.Contains(summary, `"runtimeA"`) {
+		t.Fatalf("summary missing runtime roles override:\n%s", summary)
+	}
+}
+
+func TestEmitTelemetryIncludesFlagMetadata(t *testing.T) {
+	logger := &stubStructuredLogger{}
+	resolved := &pkgconfig.ResolvedInvocation{
+		CommandPath: "chainctl cluster install",
+		SourcePath:  "/configs/chainctl.yaml",
+		Profiles:    []string{"staging"},
+		Overrides:   []string{"runtime overrides namespace (was default)"},
+		Flags: pkgconfig.FlagSet{
+			"namespace": {Value: "demo", Source: pkgconfig.ValueSourceDefault},
+			"dry-run":   {Value: true, Source: pkgconfig.ValueSourceRuntime},
+		},
+	}
+
+	EmitTelemetry(logger, resolved)
+
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 telemetry entry, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.Category != telemetry.CategoryConfig {
+		t.Fatalf("entry category = %s, want %s", entry.Category, telemetry.CategoryConfig)
+	}
+	if entry.Severity != telemetry.SeverityInfo {
+		t.Fatalf("entry severity = %s, want info", entry.Severity)
+	}
+	if entry.Message == "" || !strings.Contains(entry.Message, "declarative configuration resolved") {
+		t.Fatalf("unexpected message: %q", entry.Message)
+	}
+	if entry.Metadata["command"] != "chainctl cluster install" {
+		t.Fatalf("metadata command = %s", entry.Metadata["command"])
+	}
+	if entry.Metadata["flag.dry-run"] != "true" {
+		t.Fatalf("metadata flag.dry-run = %s", entry.Metadata["flag.dry-run"])
+	}
+	if entry.Metadata["flag.namespace.source"] != string(pkgconfig.ValueSourceDefault) {
+		t.Fatalf("metadata flag.namespace.source = %s", entry.Metadata["flag.namespace.source"])
+	}
+}
+
+type stubStructuredLogger struct {
+	entries []telemetry.Entry
+}
+
+func (s *stubStructuredLogger) Emit(entry telemetry.Entry) error {
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func TestCollectRuntimeOverridesErrorPath(t *testing.T) {
+	cmd := &cobra.Command{Use: "root"}
+	cmd.Flags().Int("count", 0, "int flag")
+	// Mark as changed with string input; GetString will be invoked and should error.
+	if err := cmd.Flags().Set("count", "5"); err != nil {
+		t.Fatalf("set count flag: %v", err)
+	}
+
+	_, err := collectRuntimeOverrides(cmd)
+	if err == nil {
+		t.Fatalf("expected error when collecting non-string flag")
+	}
+}
+
+func TestApplyResolvedFlagsHandlesUnknownAndTypeMismatch(t *testing.T) {
+	cmd := &cobra.Command{Use: "root"}
+	cmd.Flags().Bool("dry-run", false, "")
+
+	resolved := &pkgconfig.ResolvedInvocation{
+		Flags: pkgconfig.FlagSet{
+			"dry-run": {Value: "not-bool", Source: pkgconfig.ValueSourceRuntime},
+		},
+	}
+	if err := applyResolvedFlags(cmd, resolved); err == nil {
+		t.Fatalf("expected type mismatch error for bool flag")
+	}
+
+	resolved.Flags["dry-run"] = pkgconfig.FlagValue{Value: true, Source: pkgconfig.ValueSourceRuntime}
+	resolved.Flags["unknown"] = pkgconfig.FlagValue{Value: "value", Source: pkgconfig.ValueSourceRuntime}
+
+	if err := applyResolvedFlags(cmd, resolved); err != nil {
+		t.Fatalf("applyResolvedFlags returned error: %v", err)
+	}
+	if len(resolved.Warnings) == 0 {
+		t.Fatalf("expected warning for unknown flag")
+	}
+	if !strings.Contains(resolved.Warnings[0], "unknown") {
+		t.Fatalf("warning does not mention unknown flag: %s", resolved.Warnings[0])
+	}
+}
+
+func TestToStringSliceVariants(t *testing.T) {
+	values, err := toStringSlice([]interface{}{"one", 2})
+	if err != nil {
+		t.Fatalf("expected conversion success, got error: %v", err)
+	}
+	if !reflect.DeepEqual(values, []string{"one", "2"}) {
+		t.Fatalf("converted values = %#v", values)
+	}
+	if _, err := toStringSlice(map[string]any{"bad": true}); err == nil {
+		t.Fatalf("expected error for unsupported type")
+	}
+}
+
+func TestStoreAndRetrieveResolvedInvocationNilSafety(t *testing.T) {
+	storeResolvedInvocation(nil, nil)
+	if _, ok := ResolvedInvocationFromContext(nil); ok {
+		t.Fatalf("expected false for nil command")
+	}
+
+	cmd := &cobra.Command{Use: "root"}
+	if _, ok := ResolvedInvocationFromContext(cmd); ok {
+		t.Fatalf("expected false for command with no context")
+	}
+	expected := &pkgconfig.ResolvedInvocation{CommandPath: "root"}
+	storeResolvedInvocation(cmd, expected)
+	actual, ok := ResolvedInvocationFromContext(cmd)
+	if !ok || actual != expected {
+		t.Fatalf("expected resolved invocation to be stored and retrieved")
+	}
+}
+
+func TestApplySkipsWhenConfigMissing(t *testing.T) {
+	root := &cobra.Command{Use: "chainctl"}
+	root.SetErr(&bytes.Buffer{})
+	root.SetOut(&bytes.Buffer{})
+
+	cmd := &cobra.Command{
+		Use: "install",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.Annotations = map[string]string{AnnotationEnabled: "true"}
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", "text", "")
+	root.AddCommand(cmd)
+
+	manager := NewManager(root)
+	manager.Bind(root)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute without config: %v", err)
+	}
+}

--- a/docs/examples/config/chainctl.yaml
+++ b/docs/examples/config/chainctl.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: example-config
+  description: Example declarative configuration for chainctl documentation
+defaults:
+  namespace: demo
+  values-file: "./values.enc"
+profiles:
+  staging:
+    namespace: staging
+commands:
+  chainctl cluster install:
+    flags:
+      dry-run: true
+      output: json
+  chainctl app install:
+    profiles:
+      - staging
+    flags:
+      chart: oci://registry.example.com/app/demo:1.0.0
+      release-name: demo-staging

--- a/docs/examples/config/cluster_summary.json
+++ b/docs/examples/config/cluster_summary.json
@@ -1,0 +1,34 @@
+{
+  "commandPath": "chainctl cluster install",
+  "flags": [
+    {
+      "name": "dry-run",
+      "value": true,
+      "source": "command"
+    },
+    {
+      "name": "namespace",
+      "value": "runtime-ns",
+      "source": "runtime"
+    },
+    {
+      "name": "output",
+      "value": "json",
+      "source": "command"
+    },
+    {
+      "name": "values-file",
+      "value": "./values.enc",
+      "source": "default"
+    },
+    {
+      "name": "values-passphrase",
+      "value": "runtime-pass",
+      "source": "runtime"
+    }
+  ],
+  "overrides": [
+    "runtime overrides namespace (was default)"
+  ],
+  "sourcePath": "docs/examples/config/chainctl.yaml"
+}

--- a/docs/examples/config/cluster_summary.txt
+++ b/docs/examples/config/cluster_summary.txt
@@ -1,0 +1,10 @@
+Command:    chainctl cluster install
+Source:     docs/examples/config/chainctl.yaml
+Overrides:  runtime overrides namespace (was default)
+
+Flag               Value         Source
+dry-run            true          command
+namespace          runtime-ns    runtime
+output             json          command
+values-file        ./values.enc  default
+values-passphrase  runtime-pass  runtime

--- a/docs/runbooks/declarative-config.md
+++ b/docs/runbooks/declarative-config.md
@@ -1,0 +1,39 @@
+# Declarative Configuration Runbook
+
+This runbook describes how operators author and consume declarative `chainctl.yaml` files to standardise CLI executions.
+
+## Authoring
+1. Start from the sample in [`docs/examples/config/chainctl.yaml`](../examples/config/chainctl.yaml) and commit the file to version control.
+2. Populate `defaults` with non-secret flag values that apply to multiple commands (namespaces, bundle paths, `dry-run`, `output`).
+3. Define reusable `profiles` when teams share overrides (e.g., staging namespaces). Reference profiles from command sections via the `profiles` list.
+4. For each command (e.g., `chainctl cluster install`), list supported flags under `flags`. Use only flags exposed by the CLI; blocked flags return actionable errors during validation.
+5. Never include secrets (`values-passphrase`, tokens, kubeconfigs). Provide sensitive values at runtime via environment variables, CI secret stores, or prompt injection.
+
+## Distribution & Discovery
+- Operators may pass `--config /path/to/chainctl.yaml` explicitly.
+- Auto-discovery order:
+  1. `CHAINCTL_CONFIG`
+  2. `./chainctl.yaml`
+  3. `$XDG_CONFIG_HOME/chainctl/config.yaml`
+  4. `$HOME/.config/chainctl/config.yaml`
+- Once resolved, chainctl prints a summary table (text) or JSON block (when `--output json`) that lists every flag, value, and origin (default/profile/command/runtime). Review before executing destructive commands.
+
+## Override Rules
+1. Load defaults (YAML `defaults`).
+2. Apply profiles referenced by the command (`profiles` list).
+3. Apply command-specific flags (`commands[<cmd>].flags`).
+4. Apply runtime CLI overrides (`--flag value`).
+
+The summary notes all overrides so auditors can confirm provenance.
+
+## Telemetry & Logging
+- Structured logs include `category="config"` events with the resolved command, source path, profiles, and individual flag sources. Centralised logging systems can filter on this category for compliance reporting.
+- Telemetry metadata attaches the same information to the workflow entries for observability pipelines.
+
+## Troubleshooting
+- `ERR_CONFIG_NOT_FOUND`: confirm the file exists or provide an explicit `--config` path.
+- `ERR_CONFIG_UNKNOWN_COMMAND`: the YAML references a command not currently enabled; remove or update after upgrading chainctl.
+- `ERR_CONFIG_UNKNOWN_FLAG`: remove or fix the flag name; use `chainctl <cmd> --help` to enumerate valid flags.
+- `ERR_CONFIG_SECRET_BLOCKED`: relocate sensitive values (passphrases, tokens) to secret storage and inject at runtime.
+
+Store approved `chainctl.yaml` files in a central repo and review diffs like code. The merged summary emitted by chainctl should be captured alongside automation logs for traceability.

--- a/examples/config/chainctl.yaml
+++ b/examples/config/chainctl.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: example-config
+  description: Example declarative configuration for chainctl documentation
+defaults:
+  namespace: demo
+  values-file: "./values.enc"
+profiles:
+  staging:
+    namespace: staging
+commands:
+  chainctl cluster install:
+    flags:
+      dry-run: true
+      output: json
+  chainctl app install:
+    profiles:
+      - staging
+    flags:
+      chart: oci://registry.example.com/app/demo:1.0.0
+      release-name: demo-staging

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.9
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0
@@ -112,7 +113,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 
 	appcmd "github.com/dobrovols/chainctl/cmd/chainctl/app"
 	clustercmd "github.com/dobrovols/chainctl/cmd/chainctl/cluster"
+	"github.com/dobrovols/chainctl/cmd/chainctl/declarative"
 	nodecmd "github.com/dobrovols/chainctl/cmd/chainctl/node"
 	secretcmd "github.com/dobrovols/chainctl/cmd/chainctl/secrets"
 )
@@ -20,6 +21,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(nodecmd.NewNodeCommand())
 	cmd.AddCommand(clustercmd.NewClusterCommand())
 	cmd.AddCommand(appcmd.NewAppCommand())
+	declarative.NewManager(cmd).Bind(cmd)
 
 	return cmd
 }

--- a/internal/config/cobra_catalog.go
+++ b/internal/config/cobra_catalog.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// FlagType describes the expected Go type for a flag value.
+type FlagType int
+
+const (
+	FlagTypeString FlagType = iota
+	FlagTypeBool
+	FlagTypeStringSlice
+)
+
+// FlagCatalog exposes metadata about supported commands and flags.
+type FlagCatalog interface {
+	IsCommandSupported(command string) bool
+	FlagType(command, flag string) (FlagType, bool)
+	AnyFlagType(flag string) (FlagType, bool)
+	Commands() []string
+}
+
+// cobraCatalog implements FlagCatalog using a Cobra command tree.
+type cobraCatalog struct {
+	commands map[string]map[string]FlagType
+	index    map[string]FlagType
+	order    []string
+}
+
+// NewCobraCatalog builds a flag catalog from the provided Cobra root command.
+func NewCobraCatalog(root *cobra.Command) FlagCatalog {
+	c := &cobraCatalog{
+		commands: make(map[string]map[string]FlagType),
+		index:    make(map[string]FlagType),
+	}
+	traverseCommands(root, nil, c)
+	return c
+}
+
+func traverseCommands(cmd *cobra.Command, parents []string, catalog *cobraCatalog) {
+	path := append(parents, cmd.Use)
+	commandPath := strings.Join(path, " ")
+	flags := make(map[string]FlagType)
+
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		flags[flag.Name] = flagType(flag)
+	})
+
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		flags[flag.Name] = flagType(flag)
+	})
+
+	catalog.commands[commandPath] = flags
+	catalog.order = append(catalog.order, commandPath)
+
+	for name, flagType := range flags {
+		if _, ok := catalog.index[name]; !ok {
+			catalog.index[name] = flagType
+		}
+	}
+
+	for _, child := range cmd.Commands() {
+		if !child.Hidden {
+			traverseCommands(child, path, catalog)
+		}
+	}
+}
+
+func (c *cobraCatalog) IsCommandSupported(command string) bool {
+	_, ok := c.commands[command]
+	return ok
+}
+
+func (c *cobraCatalog) FlagType(command, flag string) (FlagType, bool) {
+	if flags, ok := c.commands[command]; ok {
+		t, found := flags[flag]
+		return t, found
+	}
+	return 0, false
+}
+
+func (c *cobraCatalog) AnyFlagType(flag string) (FlagType, bool) {
+	t, ok := c.index[flag]
+	return t, ok
+}
+
+func (c *cobraCatalog) Commands() []string {
+	return append([]string(nil), c.order...)
+}
+
+func flagType(flag *pflag.Flag) FlagType {
+	switch flag.Value.Type() {
+	case "bool":
+		return FlagTypeBool
+	case "stringSlice", "stringArray":
+		return FlagTypeStringSlice
+	default:
+		return FlagTypeString
+	}
+}

--- a/internal/config/cobra_catalog_test.go
+++ b/internal/config/cobra_catalog_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCobraCatalogCapturesCommandsAndFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("global", "", "global flag")
+
+	install := &cobra.Command{Use: "install"}
+	install.Flags().Bool("dry-run", false, "dry run")
+	install.Flags().StringSlice("roles", []string{}, "roles")
+
+	hidden := &cobra.Command{Use: "hidden", Hidden: true}
+
+	root.AddCommand(install, hidden)
+
+	catalog := NewCobraCatalog(root)
+
+	commands := catalog.Commands()
+	if len(commands) != 2 {
+		t.Fatalf("expected 2 commands (root and root install), got %d: %#v", len(commands), commands)
+	}
+	if !catalog.IsCommandSupported("root") {
+		t.Fatalf("expected root command to be supported")
+	}
+	if !catalog.IsCommandSupported("root install") {
+		t.Fatalf("expected root install command to be supported")
+	}
+	if catalog.IsCommandSupported("root hidden") {
+		t.Fatalf("expected hidden command to be skipped")
+	}
+
+	if flagType, ok := catalog.FlagType("root install", "dry-run"); !ok || flagType != FlagTypeBool {
+		t.Fatalf("expected dry-run flag to be bool, got ok=%t type=%v", ok, flagType)
+	}
+	if flagType, ok := catalog.FlagType("root install", "roles"); !ok || flagType != FlagTypeStringSlice {
+		t.Fatalf("expected roles flag to be string slice, got ok=%t type=%v", ok, flagType)
+	}
+	if _, ok := catalog.FlagType("root install", "nonexistent"); ok {
+		t.Fatalf("expected nonexistent flag lookup to fail")
+	}
+
+	if flagType, ok := catalog.FlagType("root install", "global"); !ok || flagType != FlagTypeString {
+		t.Fatalf("expected inherited global flag to be string, got ok=%t type=%v", ok, flagType)
+	}
+	if flagType, ok := catalog.AnyFlagType("global"); !ok || flagType != FlagTypeString {
+		t.Fatalf("expected AnyFlagType to return string for global flag, got ok=%t type=%v", ok, flagType)
+	}
+}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,3 @@
+// Package config provides helpers for resolving declarative configuration files,
+// combining YAML-defined defaults with runtime overrides before command execution.
+package config

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -82,7 +82,8 @@ func (l *Loader) Load(path string) (*pkgconfig.ConfigurationProfile, error) {
 			continue
 		}
 		if !l.catalog.IsCommandSupported(cmdPath) {
-			return nil, fmt.Errorf("%w: %s", ErrUnknownCommand, cmdPath)
+			available := l.catalog.Commands()
+			return nil, fmt.Errorf("%w: %s. Available commands: %s", ErrUnknownCommand, cmdPath, strings.Join(available, ", "))
 		}
 		flagSet, err := l.buildFlagSet(section.Flags, cmdPath, pkgconfig.ValueSourceCommand)
 		if err != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
+)
+
+var (
+	// ErrSecretsDisallowed is returned when the configuration declares a sensitive flag value.
+	ErrSecretsDisallowed = errors.New("secrets are not permitted in declarative configuration")
+	// ErrUnknownCommand indicates the configuration references a command not recognised by the CLI.
+	ErrUnknownCommand = errors.New("unknown command referenced in declarative configuration")
+	// ErrUnknownFlag indicates the configuration references an unsupported flag.
+	ErrUnknownFlag = errors.New("unknown flag referenced in declarative configuration")
+	// ErrInvalidFlagType indicates a YAML value cannot be coerced to the expected flag type.
+	ErrInvalidFlagType = errors.New("invalid flag value type")
+)
+
+// Loader parses declarative configuration files into strongly typed profiles.
+type Loader struct {
+	catalog FlagCatalog
+}
+
+// NewLoader constructs a Loader with the provided flag catalog.
+func NewLoader(catalog FlagCatalog) *Loader {
+	return &Loader{catalog: catalog}
+}
+
+// Load parses the YAML file at the supplied path, performing validation and returning a configuration profile.
+func (l *Loader) Load(path string) (*pkgconfig.ConfigurationProfile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+
+	var raw rawProfile
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&raw); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("parse declarative config %q: %w", path, err)
+	}
+
+	profile := &pkgconfig.ConfigurationProfile{
+		Metadata: pkgconfig.Metadata{
+			Name:        raw.Metadata.Name,
+			Description: raw.Metadata.Description,
+		},
+		Defaults:   pkgconfig.FlagSet{},
+		Profiles:   map[string]pkgconfig.FlagSet{},
+		Commands:   map[string]pkgconfig.CommandSection{},
+		SourcePath: path,
+	}
+
+	if len(raw.Defaults) > 0 {
+		defaults, err := l.buildFlagSet(raw.Defaults, "", pkgconfig.ValueSourceDefault)
+		if err != nil {
+			return nil, err
+		}
+		profile.Defaults = defaults
+	}
+
+	for name, entries := range raw.Profiles {
+		flagSet, err := l.buildFlagSet(entries, "", pkgconfig.ValueSourceProfile)
+		if err != nil {
+			return nil, fmt.Errorf("profile %q: %w", name, err)
+		}
+		profile.Profiles[name] = flagSet
+	}
+
+	for command, section := range raw.Commands {
+		cmdPath := strings.TrimSpace(command)
+		if cmdPath == "" {
+			continue
+		}
+		if !l.catalog.IsCommandSupported(cmdPath) {
+			return nil, fmt.Errorf("%w: %s", ErrUnknownCommand, cmdPath)
+		}
+		flagSet, err := l.buildFlagSet(section.Flags, cmdPath, pkgconfig.ValueSourceCommand)
+		if err != nil {
+			return nil, fmt.Errorf("command %q: %w", cmdPath, err)
+		}
+		profile.Commands[cmdPath] = pkgconfig.CommandSection{
+			Profiles: append([]string(nil), section.Profiles...),
+			Flags:    flagSet,
+			Disabled: section.Disabled,
+		}
+	}
+
+	return profile, nil
+}
+
+type rawProfile struct {
+	Metadata rawMetadata                  `yaml:"metadata"`
+	Defaults map[string]any               `yaml:"defaults"`
+	Profiles map[string]map[string]any    `yaml:"profiles"`
+	Commands map[string]rawCommandSection `yaml:"commands"`
+}
+
+type rawMetadata struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+type rawCommandSection struct {
+	Profiles []string       `yaml:"profiles"`
+	Flags    map[string]any `yaml:"flags"`
+	Disabled bool           `yaml:"disabled"`
+}
+
+func (l *Loader) buildFlagSet(entries map[string]any, command string, fallback pkgconfig.ValueSource) (pkgconfig.FlagSet, error) {
+	if len(entries) == 0 {
+		return pkgconfig.FlagSet{}, nil
+	}
+	set := pkgconfig.FlagSet{}
+	for name, raw := range entries {
+		if isSensitive(name) {
+			return nil, fmt.Errorf("%w: %s", ErrSecretsDisallowed, name)
+		}
+
+		var (
+			flagType FlagType
+			ok       bool
+		)
+		if command != "" {
+			flagType, ok = l.catalog.FlagType(command, name)
+		} else {
+			flagType, ok = l.catalog.AnyFlagType(name)
+		}
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrUnknownFlag, name)
+		}
+
+		value, err := coerceValue(name, raw, flagType)
+		if err != nil {
+			return nil, err
+		}
+
+		set[name] = pkgconfig.FlagValue{
+			Value:  value,
+			Source: fallback,
+		}
+	}
+	return set, nil
+}
+
+func isSensitive(name string) bool {
+	lower := strings.ToLower(name)
+	sensitive := []string{"token", "secret", "passphrase", "password", "kubeconfig"}
+	for _, marker := range sensitive {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func coerceValue(name string, raw any, flagType FlagType) (any, error) {
+	switch flagType {
+	case FlagTypeBool:
+		switch v := raw.(type) {
+		case bool:
+			return v, nil
+		case string:
+			value, err := strconv.ParseBool(strings.TrimSpace(v))
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s expects boolean", ErrInvalidFlagType, name)
+			}
+			return value, nil
+		default:
+			return nil, fmt.Errorf("%w: %s expects boolean", ErrInvalidFlagType, name)
+		}
+	case FlagTypeStringSlice:
+		switch v := raw.(type) {
+		case []interface{}:
+			out := make([]string, len(v))
+			for i, item := range v {
+				str, err := stringify(name, item)
+				if err != nil {
+					return nil, err
+				}
+				out[i] = str
+			}
+			return out, nil
+		case []string:
+			return append([]string(nil), v...), nil
+		case string:
+			return []string{strings.TrimSpace(v)}, nil
+		default:
+			return nil, fmt.Errorf("%w: %s expects string list", ErrInvalidFlagType, name)
+		}
+	default:
+		str, err := stringify(name, raw)
+		if err != nil {
+			return nil, err
+		}
+		return str, nil
+	}
+}
+
+func stringify(name string, value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case fmt.Stringer:
+		return v.String(), nil
+	case int, int64, float64, float32:
+		return fmt.Sprint(v), nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	default:
+		return "", fmt.Errorf("%w: %s expects string-compatible value", ErrInvalidFlagType, name)
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,0 +1,199 @@
+package config_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	internalconfig "github.com/dobrovols/chainctl/internal/config"
+	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
+)
+
+func TestLoadProfileParsesYAMLDocument(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "chainctl.yaml")
+	writeConfigFile(t, path, `
+metadata:
+  name: shared-demo
+  description: Example profile
+defaults:
+  namespace: demo
+  bundle-path: ./bundle.tgz
+profiles:
+  staging:
+    namespace: staging
+commands:
+  chainctl cluster install:
+    profiles:
+      - staging
+    flags:
+      chart: oci://example/cluster:1.0.0
+      dry-run: true
+      values-file: ./values.enc
+`)
+
+	catalog := fakeCatalog{
+		commands: map[string]map[string]internalconfig.FlagType{
+			"chainctl cluster install": {
+				"namespace":         internalconfig.FlagTypeString,
+				"bundle-path":       internalconfig.FlagTypeString,
+				"chart":             internalconfig.FlagTypeString,
+				"dry-run":           internalconfig.FlagTypeBool,
+				"values-file":       internalconfig.FlagTypeString,
+				"values-passphrase": internalconfig.FlagTypeString,
+			},
+		},
+	}
+
+	loader := internalconfig.NewLoader(catalog)
+	profile, err := loader.Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if profile == nil {
+		t.Fatalf("expected profile, got nil")
+	}
+	if profile.SourcePath != path {
+		t.Fatalf("expected source path %q, got %q", path, profile.SourcePath)
+	}
+	if profile.Metadata.Name != "shared-demo" {
+		t.Fatalf("expected metadata name to be shared-demo, got %s", profile.Metadata.Name)
+	}
+	if profile.Defaults["namespace"].Value != "demo" {
+		t.Fatalf("expected default namespace demo, got %v", profile.Defaults["namespace"].Value)
+	}
+	install := profile.Commands["chainctl cluster install"]
+	if len(install.Profiles) != 1 || install.Profiles[0] != "staging" {
+		t.Fatalf("expected staging profile reference, got %#v", install.Profiles)
+	}
+	if install.Flags["dry-run"].Value != true {
+		t.Fatalf("expected dry-run true, got %v", install.Flags["dry-run"].Value)
+	}
+	if install.Flags["chart"].Source != pkgconfig.ValueSourceCommand {
+		t.Fatalf("expected chart source command, got %s", install.Flags["chart"].Source)
+	}
+}
+
+func TestLoadProfileRejectsSecrets(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "chainctl.yaml")
+	writeConfigFile(t, path, `
+defaults:
+  values-passphrase: super-secret
+commands:
+  chainctl cluster install:
+    flags:
+      chart: oci://example/cluster:1.0.0
+`)
+
+	catalog := fakeCatalog{
+		commands: map[string]map[string]internalconfig.FlagType{
+			"chainctl cluster install": {
+				"chart":             internalconfig.FlagTypeString,
+				"values-passphrase": internalconfig.FlagTypeString,
+			},
+		},
+	}
+
+	loader := internalconfig.NewLoader(catalog)
+	_, err := loader.Load(path)
+	if !errors.Is(err, internalconfig.ErrSecretsDisallowed) {
+		t.Fatalf("expected ErrSecretsDisallowed, got %v", err)
+	}
+}
+
+func TestLoadProfileRejectsUnknownCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "chainctl.yaml")
+	writeConfigFile(t, path, `
+commands:
+  chainctl invalid action:
+    flags:
+      chart: oci://example/cluster:1.0.0
+`)
+
+	catalog := fakeCatalog{
+		commands: map[string]map[string]internalconfig.FlagType{},
+	}
+
+	loader := internalconfig.NewLoader(catalog)
+	_, err := loader.Load(path)
+	if !errors.Is(err, internalconfig.ErrUnknownCommand) {
+		t.Fatalf("expected ErrUnknownCommand, got %v", err)
+	}
+}
+
+func TestLoadProfileRejectsUnknownFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "chainctl.yaml")
+	writeConfigFile(t, path, `
+commands:
+  chainctl cluster install:
+    flags:
+      unknown-flag: value
+`)
+
+	catalog := fakeCatalog{
+		commands: map[string]map[string]internalconfig.FlagType{
+			"chainctl cluster install": {
+				"chart": internalconfig.FlagTypeString,
+			},
+		},
+	}
+
+	loader := internalconfig.NewLoader(catalog)
+	_, err := loader.Load(path)
+	if !errors.Is(err, internalconfig.ErrUnknownFlag) {
+		t.Fatalf("expected ErrUnknownFlag, got %v", err)
+	}
+}
+
+func writeConfigFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := mustMkdirAll(path); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func mustMkdirAll(path string) error {
+	return os.MkdirAll(filepath.Dir(path), 0o755)
+}
+
+type fakeCatalog struct {
+	commands map[string]map[string]internalconfig.FlagType
+}
+
+func (c fakeCatalog) IsCommandSupported(command string) bool {
+	_, ok := c.commands[command]
+	return ok
+}
+
+func (c fakeCatalog) FlagType(command, flag string) (internalconfig.FlagType, bool) {
+	flags, ok := c.commands[command]
+	if !ok {
+		return 0, false
+	}
+	t, ok := flags[flag]
+	return t, ok
+}
+
+func (c fakeCatalog) AnyFlagType(flag string) (internalconfig.FlagType, bool) {
+	for _, flags := range c.commands {
+		if t, ok := flags[flag]; ok {
+			return t, true
+		}
+	}
+	return 0, false
+}
+
+func (c fakeCatalog) Commands() []string {
+	out := make([]string, 0, len(c.commands))
+	for name := range c.commands {
+		out = append(out, name)
+	}
+	return out
+}

--- a/internal/config/locator.go
+++ b/internal/config/locator.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ConfigSource identifies where the configuration file was discovered.
+type ConfigSource string
+
+const (
+	ConfigSourceExplicit   ConfigSource = "explicit"
+	ConfigSourceEnv        ConfigSource = "env"
+	ConfigSourceWorkingDir ConfigSource = "working-dir"
+	ConfigSourceXDG        ConfigSource = "xdg"
+	ConfigSourceHome       ConfigSource = "home"
+)
+
+// LocationResult describes the discovered configuration file.
+type LocationResult struct {
+	Path   string
+	Source ConfigSource
+}
+
+// ErrConfigNotFound is returned when no configuration file can be located.
+var ErrConfigNotFound = errors.New("declarative configuration not found")
+
+// LocateConfig discovers the declarative configuration file following the precedence rules:
+// explicit path → CHAINCTL_CONFIG → ./chainctl.yaml → XDG config → ~/.config/chainctl/config.yaml.
+func LocateConfig(explicitPath string) (LocationResult, error) {
+	if path := strings.TrimSpace(explicitPath); path != "" {
+		clean := filepath.Clean(path)
+		abs, err := toAbsolute(clean)
+		if err != nil {
+			return LocationResult{}, err
+		}
+		if exists(abs) {
+			return LocationResult{Path: abs, Source: ConfigSourceExplicit}, nil
+		}
+		return LocationResult{}, fmt.Errorf("%w: %s", ErrConfigNotFound, abs)
+	}
+
+	if path, ok := os.LookupEnv("CHAINCTL_CONFIG"); ok && strings.TrimSpace(path) != "" {
+		abs, err := toAbsolute(path)
+		if err != nil {
+			return LocationResult{}, err
+		}
+		if exists(abs) {
+			return LocationResult{Path: abs, Source: ConfigSourceEnv}, nil
+		}
+		return LocationResult{}, fmt.Errorf("%w: %s", ErrConfigNotFound, abs)
+	}
+
+	if wd, err := os.Getwd(); err == nil {
+		path := filepath.Join(wd, "chainctl.yaml")
+		if exists(path) {
+			return LocationResult{Path: path, Source: ConfigSourceWorkingDir}, nil
+		}
+	}
+
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		path := filepath.Join(xdg, "chainctl", "config.yaml")
+		if exists(path) {
+			return LocationResult{Path: path, Source: ConfigSourceXDG}, nil
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		path := filepath.Join(home, ".config", "chainctl", "config.yaml")
+		if exists(path) {
+			return LocationResult{Path: path, Source: ConfigSourceHome}, nil
+		}
+	}
+
+	return LocationResult{}, ErrConfigNotFound
+}
+
+func toAbsolute(path string) (string, error) {
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("absolute path: %w", err)
+	}
+	return abs, nil
+}
+
+func exists(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !stat.IsDir()
+}

--- a/internal/config/locator_test.go
+++ b/internal/config/locator_test.go
@@ -1,0 +1,157 @@
+package config_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dobrovols/chainctl/internal/config"
+)
+
+func TestLocateConfigExplicitPathHasPriority(t *testing.T) {
+	tmpDir := t.TempDir()
+	explicitPath := filepath.Join(tmpDir, "explicit.yaml")
+	mustWriteFile(t, explicitPath, "key: value")
+
+	t.Setenv("CHAINCTL_CONFIG", filepath.Join(tmpDir, "env.yaml"))
+	mustWriteFile(t, os.Getenv("CHAINCTL_CONFIG"), "env: value")
+
+	result, err := config.LocateConfig(explicitPath)
+	if err != nil {
+		t.Fatalf("LocateConfig returned error: %v", err)
+	}
+	if result.Path != explicitPath {
+		t.Fatalf("expected explicit path %q, got %q", explicitPath, result.Path)
+	}
+	if result.Source != config.ConfigSourceExplicit {
+		t.Fatalf("expected explicit source, got %s", result.Source)
+	}
+}
+
+func TestLocateConfigEnvironmentVariable(t *testing.T) {
+	tmpDir := t.TempDir()
+	envPath := filepath.Join(tmpDir, "env.yaml")
+	mustWriteFile(t, envPath, "env: value")
+
+	t.Setenv("CHAINCTL_CONFIG", envPath)
+
+	result, err := config.LocateConfig("")
+	if err != nil {
+		t.Fatalf("LocateConfig returned error: %v", err)
+	}
+	if result.Path != envPath {
+		t.Fatalf("expected env path %q, got %q", envPath, result.Path)
+	}
+	if result.Source != config.ConfigSourceEnv {
+		t.Fatalf("expected env source, got %s", result.Source)
+	}
+}
+
+func TestLocateConfigWorkingDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	restoreWD := changeWorkingDir(t, tmpDir)
+	t.Cleanup(restoreWD)
+
+	wdPath := filepath.Join(tmpDir, "chainctl.yaml")
+	mustWriteFile(t, wdPath, "wd: value")
+
+	t.Setenv("CHAINCTL_CONFIG", "")
+
+	result, err := config.LocateConfig("")
+	if err != nil {
+		t.Fatalf("LocateConfig returned error: %v", err)
+	}
+	expectedPath, err := filepath.EvalSymlinks(wdPath)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	actualPath, err := filepath.EvalSymlinks(result.Path)
+	if err != nil {
+		t.Fatalf("eval result symlinks: %v", err)
+	}
+	if actualPath != expectedPath {
+		t.Fatalf("expected working directory path %q, got %q", expectedPath, actualPath)
+	}
+	if result.Source != config.ConfigSourceWorkingDir {
+		t.Fatalf("expected working-dir source, got %s", result.Source)
+	}
+}
+
+func TestLocateConfigXDGDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("CHAINCTL_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	xdgPath := filepath.Join(tmpDir, "chainctl", "config.yaml")
+	mustWriteFile(t, xdgPath, "xdg: value")
+
+	result, err := config.LocateConfig("")
+	if err != nil {
+		t.Fatalf("LocateConfig returned error: %v", err)
+	}
+	if result.Path != xdgPath {
+		t.Fatalf("expected XDG path %q, got %q", xdgPath, result.Path)
+	}
+	if result.Source != config.ConfigSourceXDG {
+		t.Fatalf("expected XDG source, got %s", result.Source)
+	}
+}
+
+func TestLocateConfigHomeDirectoryFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("CHAINCTL_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", tmpDir)
+
+	homePath := filepath.Join(tmpDir, ".config", "chainctl", "config.yaml")
+	mustWriteFile(t, homePath, "home: value")
+
+	result, err := config.LocateConfig("")
+	if err != nil {
+		t.Fatalf("LocateConfig returned error: %v", err)
+	}
+	if result.Path != homePath {
+		t.Fatalf("expected home fallback path %q, got %q", homePath, result.Path)
+	}
+	if result.Source != config.ConfigSourceHome {
+		t.Fatalf("expected home source, got %s", result.Source)
+	}
+}
+
+func TestLocateConfigMissingReturnsError(t *testing.T) {
+	t.Setenv("CHAINCTL_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	_, err := config.LocateConfig("")
+	if err == nil {
+		t.Fatalf("expected error when no configuration file is present")
+	}
+	if !errors.Is(err, config.ErrConfigNotFound) {
+		t.Fatalf("expected ErrConfigNotFound, got %v", err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+}
+
+func changeWorkingDir(t *testing.T, dir string) func() {
+	t.Helper()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return func() {
+		_ = os.Chdir(original)
+	}
+}

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,0 +1,3 @@
+// Package config exposes declarative configuration types and resolvers that map
+// YAML-defined command profiles into the flag structures consumed by chainctl commands.
+package config

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -1,0 +1,84 @@
+package config
+
+// ValueSource identifies where a flag value originated within the precedence chain.
+type ValueSource string
+
+const (
+	// ValueSourceDefault indicates the value originated from the top-level defaults.
+	ValueSourceDefault ValueSource = "default"
+	// ValueSourceProfile indicates the value came from a reusable profile grouping.
+	ValueSourceProfile ValueSource = "profile"
+	// ValueSourceCommand indicates the value came from the command-specific section.
+	ValueSourceCommand ValueSource = "command"
+	// ValueSourceRuntime indicates the value was supplied directly at runtime.
+	ValueSourceRuntime ValueSource = "runtime"
+)
+
+// FlagValue stores a typed flag value and its precedence origin.
+type FlagValue struct {
+	Value  any
+	Source ValueSource
+}
+
+// FlagSet represents a mapping of flag names to values.
+type FlagSet map[string]FlagValue
+
+// Clone creates a deep copy of the flag set so future mutations do not affect the original.
+func (f FlagSet) Clone() FlagSet {
+	if len(f) == 0 {
+		return FlagSet{}
+	}
+	out := make(FlagSet, len(f))
+	for k, v := range f {
+		out[k] = v
+	}
+	return out
+}
+
+// Metadata captures optional descriptive fields for a configuration profile.
+type Metadata struct {
+	Name        string
+	Description string
+}
+
+// CommandSection represents the configuration for a specific command path.
+type CommandSection struct {
+	Profiles []string
+	Flags    FlagSet
+	Disabled bool
+}
+
+// Clone produces a deep copy of the command section.
+func (c CommandSection) Clone() CommandSection {
+	out := CommandSection{
+		Disabled: c.Disabled,
+	}
+	if len(c.Profiles) > 0 {
+		out.Profiles = append([]string(nil), c.Profiles...)
+	}
+	if len(c.Flags) > 0 {
+		out.Flags = c.Flags.Clone()
+	} else {
+		out.Flags = FlagSet{}
+	}
+	return out
+}
+
+// ConfigurationProfile represents the parsed YAML configuration covering all supported commands.
+type ConfigurationProfile struct {
+	Metadata   Metadata
+	Defaults   FlagSet
+	Profiles   map[string]FlagSet
+	Commands   map[string]CommandSection
+	SourcePath string
+}
+
+// ResolvedInvocation captures the effective flag set for a single command after precedence resolution.
+type ResolvedInvocation struct {
+	CommandPath string
+	Profiles    []string
+	Flags       FlagSet
+	Overrides   []string
+	Warnings    []string
+	SourcePath  string
+}

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -1,0 +1,40 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dobrovols/chainctl/pkg/config"
+)
+
+func TestFlagSetCloneIsIndependent(t *testing.T) {
+	source := config.FlagSet{
+		"namespace": {Value: "demo", Source: config.ValueSourceDefault},
+	}
+
+	cloned := source.Clone()
+	cloned["namespace"] = config.FlagValue{Value: "other", Source: config.ValueSourceCommand}
+
+	if source["namespace"].Value != "demo" {
+		t.Fatalf("expected original flag set to remain unchanged, got %v", source["namespace"].Value)
+	}
+}
+
+func TestCommandSectionCloneCopiesProfilesAndFlags(t *testing.T) {
+	section := config.CommandSection{
+		Profiles: []string{"staging"},
+		Flags: config.FlagSet{
+			"chart": {Value: "oci://example/app:1.0.0", Source: config.ValueSourceCommand},
+		},
+	}
+
+	cloned := section.Clone()
+	cloned.Profiles[0] = "prod"
+	cloned.Flags["chart"] = config.FlagValue{Value: "oci://example/app:2.0.0", Source: config.ValueSourceCommand}
+
+	if section.Profiles[0] != "staging" {
+		t.Fatalf("expected original profiles slice to remain unchanged, got %s", section.Profiles[0])
+	}
+	if section.Flags["chart"].Value != "oci://example/app:1.0.0" {
+		t.Fatalf("expected original flag value unchanged, got %v", section.Flags["chart"].Value)
+	}
+}

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrCommandNotDeclared indicates the requested command is absent from the declarative configuration.
+	ErrCommandNotDeclared = errors.New("command not declared in configuration")
+	// ErrCommandDisabled indicates the command was explicitly disabled in the declarative configuration.
+	ErrCommandDisabled = errors.New("command disabled in configuration")
+	// ErrUnknownProfile indicates a referenced profile name could not be found.
+	ErrUnknownProfile = errors.New("profile not defined in configuration")
+)
+
+// ResolveInvocation merges defaults, reusable profiles, command-specific entries, and runtime overrides
+// into a single flag set for the provided command path.
+func ResolveInvocation(profile *ConfigurationProfile, commandPath string, runtime FlagSet) (*ResolvedInvocation, error) {
+	if profile == nil {
+		return nil, ErrCommandNotDeclared
+	}
+
+	section, ok := profile.Commands[commandPath]
+	if !ok {
+		return nil, ErrCommandNotDeclared
+	}
+	if section.Disabled {
+		return nil, ErrCommandDisabled
+	}
+
+	resolved := &ResolvedInvocation{
+		CommandPath: commandPath,
+		Flags:       FlagSet{},
+		SourcePath:  profile.SourcePath,
+	}
+	if len(section.Profiles) > 0 {
+		resolved.Profiles = append([]string(nil), section.Profiles...)
+	}
+
+	apply := func(source string, set FlagSet, fallback ValueSource) {
+		if len(set) == 0 {
+			return
+		}
+		for name, value := range set {
+			current := value
+			if current.Source == "" {
+				current.Source = fallback
+			}
+			if previous, ok := resolved.Flags[name]; ok {
+				resolved.Overrides = append(resolved.Overrides, fmt.Sprintf("%s overrides %s (was %s)", source, name, previous.Source))
+			}
+			resolved.Flags[name] = current
+		}
+	}
+
+	if profile.Defaults != nil {
+		apply("defaults", profile.Defaults, ValueSourceDefault)
+	}
+
+	if len(section.Profiles) > 0 {
+		for _, name := range section.Profiles {
+			flagSet, ok := profile.Profiles[name]
+			if !ok {
+				return nil, fmt.Errorf("%w: %s", ErrUnknownProfile, name)
+			}
+			apply("profile "+name, flagSet, ValueSourceProfile)
+		}
+	}
+
+	if section.Flags != nil {
+		apply("command "+commandPath, section.Flags, ValueSourceCommand)
+	}
+
+	if runtime != nil {
+		runtimeSet := runtime.Clone()
+		for name, fv := range runtimeSet {
+			if fv.Source == "" {
+				fv.Source = ValueSourceRuntime
+			}
+			runtimeSet[name] = fv
+		}
+		apply("runtime", runtimeSet, ValueSourceRuntime)
+	}
+
+	return resolved, nil
+}

--- a/pkg/config/resolver_bench_test.go
+++ b/pkg/config/resolver_bench_test.go
@@ -1,0 +1,40 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dobrovols/chainctl/pkg/config"
+)
+
+func BenchmarkResolveInvocation(b *testing.B) {
+	profile := &config.ConfigurationProfile{
+		Defaults: config.FlagSet{
+			"namespace":   {Value: "demo", Source: config.ValueSourceDefault},
+			"values-file": {Value: "/etc/chainctl/values.enc", Source: config.ValueSourceDefault},
+		},
+		Profiles: map[string]config.FlagSet{
+			"staging": {
+				"namespace": {Value: "staging", Source: config.ValueSourceProfile},
+			},
+		},
+		Commands: map[string]config.CommandSection{
+			"chainctl cluster install": {
+				Profiles: []string{"staging"},
+				Flags: config.FlagSet{
+					"output": {Value: "json", Source: config.ValueSourceCommand},
+				},
+			},
+		},
+	}
+
+	runtime := config.FlagSet{
+		"namespace": {Value: "runtime", Source: config.ValueSourceRuntime},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := config.ResolveInvocation(profile, "chainctl cluster install", runtime); err != nil {
+			b.Fatalf("resolve invocation: %v", err)
+		}
+	}
+}

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -1,0 +1,106 @@
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dobrovols/chainctl/pkg/config"
+)
+
+func TestResolveInvocationMergesDefaultsCommandAndRuntime(t *testing.T) {
+	profile := &config.ConfigurationProfile{
+		Defaults: config.FlagSet{
+			"namespace": {Value: "demo", Source: config.ValueSourceDefault},
+		},
+		Commands: map[string]config.CommandSection{
+			"chainctl cluster install": {
+				Flags: config.FlagSet{
+					"chart": {Value: "oci://example/cluster:1.0.0", Source: config.ValueSourceCommand},
+				},
+			},
+		},
+		SourcePath: "/tmp/chainctl.yaml",
+	}
+
+	runtime := config.FlagSet{
+		"namespace": {Value: "demo-override", Source: config.ValueSourceRuntime},
+	}
+
+	resolved, err := config.ResolveInvocation(profile, "chainctl cluster install", runtime)
+	if err != nil {
+		t.Fatalf("ResolveInvocation returned error: %v", err)
+	}
+	if resolved.Flags["namespace"].Value != "demo-override" {
+		t.Fatalf("expected namespace override, got %v", resolved.Flags["namespace"].Value)
+	}
+	if resolved.Flags["namespace"].Source != config.ValueSourceRuntime {
+		t.Fatalf("expected runtime source, got %s", resolved.Flags["namespace"].Source)
+	}
+	if resolved.Flags["chart"].Value != "oci://example/cluster:1.0.0" {
+		t.Fatalf("expected chart value retained, got %v", resolved.Flags["chart"].Value)
+	}
+	if resolved.Flags["chart"].Source != config.ValueSourceCommand {
+		t.Fatalf("expected chart source command, got %s", resolved.Flags["chart"].Source)
+	}
+	if len(resolved.Overrides) == 0 {
+		t.Fatalf("expected overrides to record runtime precedence")
+	}
+}
+
+func TestResolveInvocationProfilesApply(t *testing.T) {
+	profile := &config.ConfigurationProfile{
+		Defaults: config.FlagSet{
+			"namespace": {Value: "demo", Source: config.ValueSourceDefault},
+		},
+		Profiles: map[string]config.FlagSet{
+			"staging": {
+				"namespace": {Value: "staging", Source: config.ValueSourceProfile},
+			},
+		},
+		Commands: map[string]config.CommandSection{
+			"chainctl app install": {
+				Profiles: []string{"staging"},
+				Flags: config.FlagSet{
+					"chart": {Value: "oci://example/app:1.0.0", Source: config.ValueSourceCommand},
+				},
+			},
+		},
+	}
+
+	resolved, err := config.ResolveInvocation(profile, "chainctl app install", nil)
+	if err != nil {
+		t.Fatalf("ResolveInvocation returned error: %v", err)
+	}
+	if resolved.Flags["namespace"].Value != "staging" {
+		t.Fatalf("expected namespace from staging profile, got %v", resolved.Flags["namespace"].Value)
+	}
+	if resolved.Flags["namespace"].Source != config.ValueSourceProfile {
+		t.Fatalf("expected profile source, got %s", resolved.Flags["namespace"].Source)
+	}
+}
+
+func TestResolveInvocationDisabledCommand(t *testing.T) {
+	profile := &config.ConfigurationProfile{
+		Commands: map[string]config.CommandSection{
+			"chainctl cluster install": {
+				Disabled: true,
+			},
+		},
+	}
+
+	_, err := config.ResolveInvocation(profile, "chainctl cluster install", nil)
+	if !errors.Is(err, config.ErrCommandDisabled) {
+		t.Fatalf("expected ErrCommandDisabled, got %v", err)
+	}
+}
+
+func TestResolveInvocationUnknownCommand(t *testing.T) {
+	profile := &config.ConfigurationProfile{
+		Commands: map[string]config.CommandSection{},
+	}
+
+	_, err := config.ResolveInvocation(profile, "chainctl cluster install", nil)
+	if !errors.Is(err, config.ErrCommandNotDeclared) {
+		t.Fatalf("expected ErrCommandNotDeclared, got %v", err)
+	}
+}

--- a/pkg/config/summary.go
+++ b/pkg/config/summary.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// Supported summary output formats.
+const (
+	SummaryFormatText = "text"
+	SummaryFormatJSON = "json"
+)
+
+// FormatSummary renders a resolved invocation summary in the requested format.
+func FormatSummary(resolved *ResolvedInvocation, format string) (string, error) {
+	if resolved == nil {
+		return "", fmt.Errorf("resolved invocation is nil")
+	}
+
+	switch strings.ToLower(format) {
+	case "", SummaryFormatText:
+		return formatSummaryText(resolved)
+	case SummaryFormatJSON:
+		return formatSummaryJSON(resolved)
+	default:
+		return "", fmt.Errorf("unsupported summary format %q", format)
+	}
+}
+
+func formatSummaryText(resolved *ResolvedInvocation) (string, error) {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Command:\t%s\n", resolved.CommandPath)
+	if resolved.SourcePath != "" {
+		fmt.Fprintf(tw, "Source:\t%s\n", resolved.SourcePath)
+	}
+	if len(resolved.Profiles) > 0 {
+		fmt.Fprintf(tw, "Profiles:\t%s\n", strings.Join(resolved.Profiles, ", "))
+	}
+	if len(resolved.Overrides) > 0 {
+		fmt.Fprintf(tw, "Overrides:\t%s\n", strings.Join(resolved.Overrides, ", "))
+	}
+	if len(resolved.Warnings) > 0 {
+		fmt.Fprintf(tw, "Warnings:\t%s\n", strings.Join(resolved.Warnings, ", "))
+	}
+	fmt.Fprintln(tw)
+	fmt.Fprintln(tw, "Flag\tValue\tSource")
+
+	names := make([]string, 0, len(resolved.Flags))
+	for name := range resolved.Flags {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		value := resolved.Flags[name]
+		fmt.Fprintf(tw, "%s\t%v\t%s\n", name, formatFlagValue(value.Value), value.Source)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return "", fmt.Errorf("flush summary: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func formatSummaryJSON(resolved *ResolvedInvocation) (string, error) {
+	type flagEntry struct {
+		Name   string      `json:"name"`
+		Value  interface{} `json:"value"`
+		Source ValueSource `json:"source"`
+	}
+
+	names := make([]string, 0, len(resolved.Flags))
+	for name := range resolved.Flags {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	flags := make([]flagEntry, 0, len(names))
+	for _, name := range names {
+		value := resolved.Flags[name]
+		flags = append(flags, flagEntry{
+			Name:   name,
+			Value:  value.Value,
+			Source: value.Source,
+		})
+	}
+
+	payload := map[string]interface{}{
+		"commandPath": resolved.CommandPath,
+		"sourcePath":  resolved.SourcePath,
+		"flags":       flags,
+	}
+	if len(resolved.Profiles) > 0 {
+		payload["profiles"] = resolved.Profiles
+	}
+	if len(resolved.Overrides) > 0 {
+		payload["overrides"] = resolved.Overrides
+	}
+	if len(resolved.Warnings) > 0 {
+		payload["warnings"] = resolved.Warnings
+	}
+
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal summary json: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func formatFlagValue(value any) any {
+	switch v := value.(type) {
+	case []string:
+		return strings.Join(v, ",")
+	case []interface{}:
+		items := make([]string, len(v))
+		for i, item := range v {
+			items[i] = fmt.Sprint(item)
+		}
+		return strings.Join(items, ",")
+	default:
+		return v
+	}
+}

--- a/pkg/config/summary_test.go
+++ b/pkg/config/summary_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatSummaryTextAndJSON(t *testing.T) {
+	resolved := &ResolvedInvocation{
+		CommandPath: "chainctl cluster install",
+		SourcePath:  "/etc/chainctl/chainctl.yaml",
+		Profiles:    []string{"staging"},
+		Overrides:   []string{"runtime overrides namespace (was default)"},
+		Flags: FlagSet{
+			"namespace": {Value: "demo", Source: ValueSourceDefault},
+			"dry-run":   {Value: true, Source: ValueSourceRuntime},
+			"roles":     {Value: []string{"ops", "infra"}, Source: ValueSourceProfile},
+			"notes":     {Value: []interface{}{"checked", 1}, Source: ValueSourceCommand},
+		},
+	}
+
+	textSummary, err := FormatSummary(resolved, SummaryFormatText)
+	if err != nil {
+		t.Fatalf("text summary error: %v", err)
+	}
+	if !strings.Contains(textSummary, "Command:    chainctl cluster install") {
+		t.Fatalf("text summary missing command header:\n%s", textSummary)
+	}
+	if !strings.Contains(textSummary, "roles      ops,infra  profile") {
+		t.Fatalf("text summary missing roles row:\n%s", textSummary)
+	}
+	if !strings.Contains(textSummary, "notes      checked,1  command") {
+		t.Fatalf("text summary missing notes row:\n%s", textSummary)
+	}
+
+	jsonSummary, err := FormatSummary(resolved, SummaryFormatJSON)
+	if err != nil {
+		t.Fatalf("json summary error: %v", err)
+	}
+	var payload struct {
+		CommandPath string `json:"commandPath"`
+		Flags       []struct {
+			Name   string      `json:"name"`
+			Value  interface{} `json:"value"`
+			Source ValueSource `json:"source"`
+		} `json:"flags"`
+	}
+	if err := json.Unmarshal([]byte(jsonSummary), &payload); err != nil {
+		t.Fatalf("unmarshal json summary: %v", err)
+	}
+	if payload.CommandPath != "chainctl cluster install" {
+		t.Fatalf("payload commandPath = %s", payload.CommandPath)
+	}
+	if len(payload.Flags) != 4 {
+		t.Fatalf("expected 4 flags, got %d", len(payload.Flags))
+	}
+
+	if _, err := FormatSummary(resolved, "invalid-format"); err == nil {
+		t.Fatalf("expected error for unsupported format")
+	}
+}

--- a/pkg/telemetry/logger.go
+++ b/pkg/telemetry/logger.go
@@ -36,6 +36,8 @@ const (
 	CategoryCommand Category = "command"
 	// CategoryDiagnostic marks ancillary diagnostic events.
 	CategoryDiagnostic Category = "diagnostic"
+	// CategoryConfig marks declarative configuration events.
+	CategoryConfig Category = "config"
 )
 
 // Entry describes a structured log entry prior to serialization.

--- a/specs/004-declarative-config-file/contracts/config-schema.yaml
+++ b/specs/004-declarative-config-file/contracts/config-schema.yaml
@@ -1,0 +1,69 @@
+# Declarative Configuration Schema (conceptual)
+#
+# This schema outlines the supported YAML structure for declarative flag management.
+# It is expressed using OpenAPI-like syntax for documentation purposes and will
+# be enforced via custom Go validation logic.
+
+openapi: 3.1.0
+info:
+  title: chainctl Declarative Configuration
+  version: 0.1.0
+
+components:
+  schemas:
+    ConfigurationProfile:
+      type: object
+      additionalProperties: false
+      properties:
+        metadata:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+        defaults:
+          $ref: '#/components/schemas/FlagMap'
+        profiles:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/FlagMap'
+        commands:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/CommandSection'
+      required:
+        - commands
+
+    CommandSection:
+      type: object
+      additionalProperties: false
+      properties:
+        flags:
+          $ref: '#/components/schemas/FlagMap'
+        profiles:
+          type: array
+          items:
+            type: string
+        disabled:
+          type: boolean
+
+    FlagMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/FlagValue'
+
+    FlagValue:
+      oneOf:
+        - type: string
+        - type: boolean
+        - type: number
+        - type: array
+          items:
+            type: string
+      description: >
+        Flag values must match the underlying flag type. Sensitive values such as
+        tokens, passwords, or kubeconfigs are prohibited and trigger validation failures.
+
+paths: {}

--- a/specs/004-declarative-config-file/contracts/validation.adoc
+++ b/specs/004-declarative-config-file/contracts/validation.adoc
@@ -1,0 +1,21 @@
+= Declarative Configuration Validation Contract
+
+== Overview
+chainctl validates declarative YAML files before executing any command. Validation failures block command execution, surface actionable errors, and emit structured logs with the offending keys.
+
+== Validation Steps
+1. **File Discovery**:: Resolve configuration path using precedence `CHAINCTL_CONFIG` → `./chainctl.yaml` → `$XDG_CONFIG_HOME/chainctl/config.yaml` → `~/.config/chainctl/config.yaml`. Missing files after discovery result in `ERR_CONFIG_NOT_FOUND`.
+2. **Parsing**:: Parse YAML with strict duplicate-key detection. Failures return `ERR_CONFIG_PARSE` plus line/column details.
+3. **Secrets Guard**:: Reject files containing sensitive flag names (token/password/secret/kubeconfig). Failure returns `ERR_CONFIG_SECRET_BLOCKED`.
+4. **Schema Validation**:: Ensure the document matches `config-schema.yaml`. Unknown command keys emit `ERR_CONFIG_UNKNOWN_COMMAND`. Unknown flags emit `ERR_CONFIG_UNKNOWN_FLAG` and the exact key path.
+5. **Resolution**:: Merge defaults → command section → runtime flags. Type coercion errors raise `ERR_CONFIG_TYPE_MISMATCH`. Disabled commands raise `ERR_CONFIG_COMMAND_DISABLED`.
+
+== Success Response
+On success, chainctl outputs a summary JSON snippet (when `--output json`) or table (default) showing:
+
+* command path
+* source path
+* applied defaults/profile names
+* runtime overrides
+
+Telemetry includes resolution duration and source path for audit trails.

--- a/specs/004-declarative-config-file/data-model.md
+++ b/specs/004-declarative-config-file/data-model.md
@@ -1,0 +1,60 @@
+# Phase 1 Data Model: Declarative Configuration Profiles
+
+## Entities
+
+### ConfigurationProfile
+- **Attributes**:
+  - `metadata.name` (string; optional human-readable identifier)
+  - `metadata.description` (string; optional summary for operators)
+  - `defaults` (map[string]any; shared flag values applied to all commands)
+  - `commands` (map[string]CommandSection; keyed by command path such as `cluster install`)
+  - `sourcePath` (string; absolute path of the loaded YAML file)
+- **Rules**:
+  - `defaults` keys MUST map to valid CLI flags for every command that consumes them; invalid keys trigger validation errors before execution.
+  - `commands` keys MUST match registered Cobra command paths; unknown commands are rejected.
+  - `sourcePath` populated after discovery to aid logging, never user-specified within YAML.
+
+### CommandSection
+- **Attributes**:
+  - `flags` (map[string]FlagValue; explicit flag overrides for the command)
+  - `profiles` ([]string; optional list referencing named reusable flag groups)
+  - `disabled` (bool; optional control to block execution via config)
+- **Rules**:
+  - `flags` keys MUST exist on the targeted command; duplicates resolved by last writer semantics during YAML parsing.
+  - `profiles` entries MUST reference known reusable sets defined under `defaults` or top-level `profiles`.
+  - `disabled` defaults to `false`; when `true`, command execution aborts with guidance.
+
+### FlagValue
+- **Attributes**:
+  - `value` (any; string, bool, numeric, list depending on flag type)
+  - `source` (enum: `default`, `command`, `runtime`; assigned during resolution)
+- **Rules**:
+  - Secret-attributed flags (token/password) MUST NOT appear with `source` equal to `default` or `command`; validation fails before runtime merge.
+  - Values MUST coerce cleanly into the destination flag type; type mismatches yield actionable errors.
+
+### ResolvedInvocation
+- **Attributes**:
+  - `commandPath` (string; Cobra command full path)
+  - `flags` (map[string]FlagValue; final flag set after merging runtime flags)
+  - `overrides` ([]string; ordered list describing precedence decisions)
+  - `warnings` ([]string; informational messages surfaced to operators)
+- **Rules**:
+  - `flags` map MUST include values for all required CLI flags either from YAML or runtime.
+  - `overrides` records each precedence step, including runtime flags that superseded YAML values to support auditing.
+  - `warnings` highlight ignored keys, deprecated flags, or disabled commands discovered during resolution.
+
+## Relationships
+- `ConfigurationProfile` aggregates multiple `CommandSection` entries plus shared `defaults`.
+- Each `CommandSection` references zero or more reusable flag group names defined in the same `ConfigurationProfile`.
+- `ResolvedInvocation` derives from combining `ConfigurationProfile.defaults`, the relevant `CommandSection.flags`, and runtime flag overrides, annotating each contributing `FlagValue`.
+
+## State Transitions
+1. **Discovery**: `ConfigurationProfile` created after locating YAML path via `internal/config/locator`.
+2. **Parsing & Validation**: YAML decoded into `ConfigurationProfile`; validation rejects unrecognized commands, flags, or secret usage before proceeding.
+3. **Resolution**: On command execution, `ResolvedInvocation` builds by merging defaults → command section → runtime flags while tracking `overrides`.
+4. **Execution Feedback**: After command completes, `warnings` and effective configuration summary surfaced, and telemetry/logging record `commandPath`, `sourcePath`, and override chain.
+
+## Validation Hooks
+- Unit tests ensure secret detection, unknown command/flag errors, and precedence ordering behave deterministically.
+- Integration tests load sample YAML files to verify that `ResolvedInvocation` matches expected flag sets for install/upgrade flows.
+- Schema validation ensures YAML structure matches `ConfigurationProfile` expectations before merging, preventing runtime panics.

--- a/specs/004-declarative-config-file/plan.md
+++ b/specs/004-declarative-config-file/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Declarative YAML Configuration for CLI Flags
+
+**Branch**: `004-declarative-config-file` | **Date**: 2025-10-10 | **Spec**: specs/004-declarative-config-file/spec.md  
+**Input**: Feature specification from `/specs/004-declarative-config-file/spec.md`
+
+## Summary
+Declarative configuration lets operators describe complete `chainctl` command invocations in YAML, enforce precedence between configuration sources, and remove secrets from shared artifacts. The plan introduces a reusable configuration loader, command-level wiring to consume the resolved flag set, validation feedback for unsupported keys, and documentation that guides teams on adopting YAML-driven workflows without breaking existing flag-based usage.
+
+## Technical Context
+**Language/Version**: Go 1.24  
+**Primary Dependencies**: `spf13/cobra`, `helm.sh/helm/v3`, internal `pkg/state`, `pkg/telemetry`, `internal/config`, YAML parsing via `gopkg.in/yaml.v3`  
+**Storage**: Local filesystem YAML files under repo or XDG config directories (read-only at runtime)  
+**Testing**: `go test ./pkg/... ./cmd/...`, envtest-based flows in `test/integration`, future e2e in `make test-e2e` covering declarative config runs  
+**Target Platform**: cross-platform CLI (macOS/Linux) executed by cluster operators  
+**Project Type**: single (monolithic CLI with shared packages)  
+**Performance Goals**: Config discovery and parsing MUST complete in <200ms per invocation and avoid new allocations that push process memory beyond existing 512MB ceiling.  
+**Constraints**: YAML MUST exclude secrets, obey precedence `CHAINCTL_CONFIG` → `./chainctl.yaml` → `$XDG_CONFIG_HOME/chainctl/config.yaml` → `~/.config/chainctl/config.yaml`, align with structured logging, preserve existing flag UX.  
+**Scale/Scope**: Must support all current `chainctl` commands (install/upgrade/app flows) with tens of flags per command and shared defaults for multiple operator teams.
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **P1 · Go Craftsmanship**: All new Go code will live in `internal/config` for discovery and a new `pkg/config` facade for consumers, both covered by gofmt/gofumpt, golangci-lint, and clear exported contracts. Plan includes docstrings outlining expected error semantics and package boundaries.
+- **P2 · Test Rigor**: Unit tests cover YAML parsing, precedence resolution, secret rejection, and CLI flag merging. Integration tests in `test/integration` simulate running `chainctl` commands with configuration files. E2E smoke test scenario is scheduled to validate `chainctl cluster install --config` with dry-run to ensure idempotency.
+- **P3 · Operator UX**: CLI updates add a `--config` flag consistent with noun-verb structure, keep `--dry-run`/`--confirm` behavior, surface JSON parity via `--output json`, and document precedence plus error messages for unrecognized keys.
+- **P4 · Performance Budgets**: Loader caches parsed YAML per path to avoid repeated IO, limits file size (<256KB warning) and ensures no blocking operations delay startup. Benchmarks will measure load latency to confirm <200ms goal.
+- **P5 · Operational Safety**: Loader emits structured logs for discovery steps, ensures secrets are never accepted, integrates telemetry timing, and provides runbook updates explaining fallback hierarchy and remediation when configs fail validation.
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/004-declarative-config-file/
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+├── contracts/           # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+```
+
+### Source Code (repository root)
+```
+cmd/chainctl/
+├── app/
+│   ├── config_flag.go           # NEW: adds --config wiring and validation hooks
+│   ├── install.go
+│   ├── flags.go
+│   └── ...
+├── cluster/
+│   └── install/
+│       └── command.go           # UPDATED: consume resolved configuration
+
+internal/
+├── config/
+│   ├── locator.go               # NEW: discovery order honoring env/working directory/XDG
+│   ├── loader.go                # NEW: YAML parsing, validation, caching
+│   └── loader_test.go
+├── validation/
+│   └── schema.go                # UPDATED: share flag validation helpers
+
+pkg/
+├── config/
+│   ├── profile.go               # NEW: exported structs for configuration profiles
+│   ├── resolver.go              # NEW: merge YAML with CLI overrides
+│   └── resolver_test.go
+├── state/
+└── telemetry/
+
+test/
+├── unit/
+│   └── config_loader_test.go    # NEW: direct loader coverage
+├── integration/
+│   └── declarative_config_test.go  # NEW: command-level scenario
+└── e2e/
+    └── declarative_config_workflow_test.go  # NEW: dry-run install via YAML
+```
+
+**Structure Decision**: Extend existing CLI architecture by introducing `pkg/config` as the public interface for declarative configuration while using `internal/config` for environment-specific discovery. Command packages call into `pkg/config` to obtain resolved flag maps, preserving current modular boundaries without spreading filesystem logic through command handlers.
+
+## Phase 0: Outline & Research
+1. Inventory unknowns from Technical Context and spec: YAML schema structure, existing flag metadata availability, best practices for precedence resolution, validation strategy for unsupported keys, and caching lifetime.
+2. Research tasks to capture in `research.md`:
+   - Document how current `cmd/chainctl/app/flags.go` defines flag metadata and determine reuse for schema validation.
+   - Explore `internal/config` existing helpers to avoid duplication and decide on new abstractions.
+   - Evaluate YAML vs. JSON schema validation approaches (choose YAML with structural validation).
+   - Establish caching approach (in-memory per command invocation vs. persistent).
+3. Each research entry records Decision, Rationale, Alternatives and resolves remaining NEEDS CLARIFICATION.
+
+## Phase 1: Design & Contracts
+1. `data-model.md` will define entities: `ConfigurationProfile`, `CommandSection`, `FlagValue`, `ResolvedInvocation`, including relationships and validation rules (no secret values, type enforcement).
+2. `/contracts/` will contain `config-schema.yaml` describing allowable YAML structure plus `validation.adoc` summarizing error responses expected by operators.
+3. `quickstart.md` will outline how to create `chainctl.yaml`, specify precedence behavior, and include verification steps with `--dry-run`.
+4. Design integration tests:
+   - Unit tests for loader/resolver.
+   - Integration test verifying CLI merges YAML with `--set flag` and outputs both human-readable and JSON summaries.
+   - E2E dry-run ensures safe application while exercising multi-command configurations with reusable profiles.
+5. Run `.specify/scripts/bash/update-agent-context.sh codex` to register the feature context for future AI assistance.
+
+## Phase 2: Task Planning Approach
+*This section describes what the /tasks command will do - DO NOT execute during /plan*
+
+**Task Generation Strategy**:
+- Use `.specify/templates/tasks-template.md` as base.
+- Derive tasks from research, data model, and contracts: create implementation tasks for loader/resolver, command wiring, tests, and documentation.
+- Tag parallelizable tasks ([P]) such as independent unit tests or documentation updates.
+
+**Ordering Strategy**:
+- Start with data/model definitions, then loader/resolver implementation, followed by CLI integration, integration tests, and documentation updates.
+- Maintain TDD cadence: write failing tests before implementation, ensure benchmarks/logging tasks after core logic.
+
+**Estimated Output**: 25–30 ordered tasks in `tasks.md`.
+
+## Phase 3+: Future Implementation
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks)  
+**Phase 5**: Validation (run gofmt/gofumpt, go test suites, quickstart, performance checks)
+
+## Complexity Tracking
+*No deviations anticipated; keep empty unless constraints change.*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|---------------------------------------|
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved
+- [ ] Complexity deviations documented
+
+---
+*Based on Constitution v1.2.0 - See `/memory/constitution.md`*

--- a/specs/004-declarative-config-file/quickstart.md
+++ b/specs/004-declarative-config-file/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Declarative YAML Configuration for chainctl
+
+## Prerequisites
+- Checkout branch `004-declarative-config-file` and build: `go build ./cmd/chainctl`
+- Ensure Helm/cluster credentials already configured for target commands
+- Create a writable working directory to store `chainctl.yaml`
+
+## Step 1 — Create Base Configuration
+1. Create `chainctl.yaml` in your working directory with the structure below:
+   ```yaml
+   metadata:
+     name: demo-shared-config
+     description: Shared defaults for demo installs
+   defaults:
+     kubeconfig: ~/.kube/config
+     namespace: demo
+   commands:
+     chainctl cluster install:
+       flags:
+         bundle-path: ./artifacts/cluster-bundle.yaml
+         dry-run: true
+   ```
+2. Save the file and ensure it contains **no secrets** (tokens, passwords, kubeconfigs with embedded credentials).
+
+## Step 2 — Run chainctl with Declarative Config
+1. Execute `./chainctl cluster install --config ./chainctl.yaml`.
+2. Confirm the CLI prints the resolved configuration summary showing:
+   - Source file path
+   - Applied defaults and command-specific flags
+   - Confirmation that `dry-run` originated from YAML
+3. Verify the command executes end-to-end without prompting for missing flags.
+
+## Step 3 — Override at Runtime
+1. Override a flag to validate precedence:  
+   `./chainctl cluster install --config ./chainctl.yaml --namespace demo-override`
+2. Inspect the summary to ensure `namespace` reflects the runtime override while other values still come from YAML.
+3. Repeat with `CHAINCTL_CONFIG=~/shared/chainctl.yaml ./chainctl cluster install` to confirm environment-variable discovery.
+
+## Step 4 — Validation Failure Exercise
+1. Add an unsupported flag (e.g., `unknown-flag: true`) under `chainctl cluster install.flags`.
+2. Rerun the command and observe the actionable error reporting the invalid key and suggested correction.
+3. Remove the invalid flag and rerun to confirm success.
+
+## Step 5 — Multi-Command Defaults
+1. Expand the YAML to include an application command:
+   ```yaml
+   profiles:
+     staging:
+       namespace: staging
+   commands:
+     chainctl app install:
+       profiles:
+         - staging
+       flags:
+         chart: oci://registry.example.com/apps/demo:1.2.3
+         release-name: demo-staging
+   ```
+2. Execute `./chainctl app install --config ./chainctl.yaml --dry-run`.
+3. Confirm the summary lists `profiles: [staging]` and that `namespace` comes from the shared profile.
+
+## Cleanup
+- Remove sample configuration files when finished: `rm chainctl.yaml`
+- Unset `CHAINCTL_CONFIG` if you exported it: `unset CHAINCTL_CONFIG`

--- a/specs/004-declarative-config-file/research.md
+++ b/specs/004-declarative-config-file/research.md
@@ -1,0 +1,25 @@
+# Phase 0 Research: Declarative YAML Configuration
+
+## Decision: Represent YAML with `defaults` plus per-command sections
+- **Rationale**: A top-level `defaults` map establishes shared flag values, while a `commands` map keyed by command path (e.g., `cluster install`) captures command-specific overrides, directly supporting FR-007 and clarifying operator expectations from Question 2.
+- **Alternatives Considered**:
+  - Separate YAML file per command: rejected to avoid configuration sprawl and support shared baselines.
+  - Deeply nested environment-level hierarchy: rejected as unnecessary complexity for current scope.
+
+## Decision: Reuse Cobra flag definitions as schema source
+- **Rationale**: Leveraging existing `cmd/chainctl/app` flag definitions ensures validation stays aligned with live CLI options, lowers duplication risk, and enables automatic detection of unsupported keys per FR-002.
+- **Alternatives Considered**:
+  - Maintaining independent schema definitions: rejected because it would drift from code and require double maintenance.
+  - Generating schema from documentation: rejected due to incomplete coverage and lack of type fidelity.
+
+## Decision: Parse YAML via `gopkg.in/yaml.v3` with in-memory caching
+- **Rationale**: The project already uses the Go toolchain; `yaml.v3` offers mature support for strict decoding and helpful error messages. Caching parsed files per path for the life of a process keeps parsing under the 200ms target and avoids repeated filesystem reads.
+- **Alternatives Considered**:
+  - Using `sigs.k8s.io/yaml`: rejected because we need strict duplicate key detection and custom error contexts not readily available.
+  - Persisting a compiled JSON representation on disk: rejected to prevent stale cache files and additional IO management.
+
+## Decision: Enforce secret-free configs via validation hook
+- **Rationale**: Secret prohibition (Question 3) is implemented by scanning declared flag names against known sensitive categories (e.g., token, password) and rejecting files containing them, guiding operators to external secret stores in accordance with FR-005.
+- **Alternatives Considered**:
+  - Allowing secrets with log redaction flags: rejected due to governance requirements and higher leak risk.
+  - Relying on documentation only: rejected because automated enforcement provides consistent safety.

--- a/specs/004-declarative-config-file/spec.md
+++ b/specs/004-declarative-config-file/spec.md
@@ -58,7 +58,7 @@ As a platform engineer standardizing `chainctl` usage across teams, I need a dec
 - [x] All mandatory sections completed
 
 ### Requirement Completeness
-- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous  
 - [x] Success criteria are measurable
 - [x] Scope is clearly bounded

--- a/specs/004-declarative-config-file/spec.md
+++ b/specs/004-declarative-config-file/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Declarative YAML Configuration for CLI Flags
+
+**Feature Branch**: `004-declarative-config-file`  
+**Created**: 2025-10-10  
+**Status**: Draft  
+**Input**: User description: "Declarative config file for all flags (YAML)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+As a platform engineer standardizing `chainctl` usage across teams, I need a declarative YAML file that captures every CLI flag value required for our workflows so we can share, review, and rerun commands consistently without relying on ad hoc shell scripts.
+
+### Acceptance Scenarios
+1. **Given** a documented YAML configuration that defines approved flag values for a supported `chainctl` command, **When** an operator executes that command while referencing the YAML, **Then** the command runs using the declared values and completes without prompting for missing inputs.
+2. **Given** a YAML configuration and additional overrides provided directly at runtime, **When** the command executes, **Then** the runtime overrides take precedence and the operator receives a summary of the effective configuration that reflects the merged result.
+
+### Edge Cases
+- What happens when the YAML defines a flag or command section that `chainctl` does not recognize?
+- How does the system handle YAML parsing errors or missing files when a workflow depends on the declarative configuration?
+
+## Clarifications
+
+### Session 2025-10-10
+- Q: What default discovery behavior should `chainctl` use for declarative YAML configs when the operator does not explicitly pass `--config` (or similar)? → A: Search order: env var `CHAINCTL_CONFIG`, then `./chainctl.yaml`, then `$XDG_CONFIG_HOME/chainctl/config.yaml` with fallback `~/.config/chainctl/config.yaml`.
+- Q: How should a declarative YAML file organize configurations when teams need to run multiple `chainctl` commands? → A: YAML supports global defaults plus command-specific overrides within one file.
+- Q: What safeguards should apply when YAML files contain sensitive flag values? → A: YAML must never contain secrets; operators must reference external secret stores.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001**: System MUST allow operators to supply a YAML file that declaratively sets flag values for any `chainctl` command that currently accepts CLI flags.
+- **FR-002**: System MUST validate the YAML against the set of supported commands and flags, rejecting execution when it encounters unknown or misspelled entries and directing the operator to the problematic keys.
+- **FR-003**: System MUST resolve the effective flag set by applying YAML-declared values first and then overriding them with any flags provided directly during invocation.
+- **FR-004**: System MUST provide a human-readable and machine-consumable summary of the resolved configuration before executing impactful actions so operators can confirm the values being applied.
+- **FR-005**: System MUST enforce that declarative YAML configurations do not contain sensitive secrets, directing operators to reference external secret stores or runtime injection mechanisms instead of embedding confidential values.
+- **FR-006**: System MUST fail fast with an actionable error message when the declarative configuration file is missing, malformed, or cannot be accessed.
+- **FR-007**: System MUST enable teams to organize YAML content with global defaults, reusable profile groups, and command-specific overrides within a single configuration artifact so related command profiles can be maintained together.
+- **FR-008**: System MUST document precedence rules and discovery order for YAML files, setting the default resolution order to: environment variable `CHAINCTL_CONFIG` if present, then `./chainctl.yaml`, then `$XDG_CONFIG_HOME/chainctl/config.yaml`, falling back to `~/.config/chainctl/config.yaml`.
+
+### Key Entities *(include if feature involves data)*
+- **Configuration Profile**: Represents a named set of flag values for a specific `chainctl` command, including metadata such as description, maintainers, intended environment, and optional reusable `profiles` groupings applied across commands.
+- **Resolved Command Invocation**: Captures the final flag set after merging declarative YAML values with on-the-fly overrides, providing transparency for audits and troubleshooting.
+
+## Dependencies & Assumptions
+- Teams already maintain version control repositories or shared storage where YAML configurations can be reviewed and approved before execution.
+- Existing flag definitions within `chainctl` remain the authoritative source for acceptable values; this feature layers a declarative input method without changing flag semantics.
+- Operators are expected to manage file permissions and secret management policies consistent with their organization's compliance requirements.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous  
+- [x] Success criteria are measurable
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [ ] Review checklist passed
+
+---

--- a/specs/004-declarative-config-file/tasks.md
+++ b/specs/004-declarative-config-file/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Declarative YAML Configuration for CLI Flags
+
+**Input**: Design documents from `/specs/004-declarative-config-file/`
+**Prerequisites**: plan.md, research.md, data-model.md, contracts/, quickstart.md
+
+## Phase 3.1: Setup
+- [x] T001 Update module deps for YAML tooling: add/verify `gopkg.in/yaml.v3` in `go.mod`; run `go mod tidy`
+- [x] T002 Ensure lint/format pipelines cover new packages: update `Makefile` or CI to include `pkg/config` and `internal/config`
+- [x] T003 Scaffold configuration packages and files: create `pkg/config` and `internal/config` directories with placeholder doc.go files
+
+## Phase 3.2: Tests First (TDD)
+- [x] T004 Write unit tests for YAML discovery precedence in `internal/config/locator_test.go`
+- [x] T005 Write unit tests for YAML parsing and secret rejection in `internal/config/loader_test.go`
+- [x] T006 [P] Author resolver unit tests for merge/override logic in `pkg/config/resolver_test.go`
+- [x] T007 Create configuration profile struct tests in `pkg/config/profile_test.go`
+- [x] T008 [P] Add CLI integration test covering `--config` precedence, reusable profiles, multi-command YAML files, and summary output (table + `--output json`) in `test/integration/declarative_config_test.go`
+- [x] T009 [P] Add CLI e2e dry-run scenario using YAML defaults in `test/e2e/declarative_config_workflow_test.go`
+- [x] T010 Define benchmark skeleton measuring loader performance in `pkg/config/resolver_bench_test.go`
+
+## Phase 3.3: Core Implementation
+- [x] T011 Implement configuration discovery order in `internal/config/locator.go`
+- [x] T012 Implement YAML parsing, validation (schema, unknown keys), and secret guard in `internal/config/loader.go`
+- [x] T013 Build exported configuration profile types in `pkg/config/profile.go`
+- [x] T014 Implement precedence resolver merging defaults, command sections, and runtime overrides in `pkg/config/resolver.go`
+- [x] T015 Wire `--config` flag and resolved flag application into `cmd/chainctl/app/config_flag.go` (new file) and update command entrypoints (`cmd/chainctl/app/install.go`, `cmd/chainctl/app/upgrade.go`, `cmd/chainctl/cluster/install/command.go`)
+- [x] T016 Emit structured logs/telemetry for configuration discovery and resolution in `pkg/telemetry` or relevant command logging hooks
+- [x] T017 Update validation helpers to surface actionable errors for unknown flags/commands in `internal/validation/schema.go`
+
+## Phase 3.4: Integration & Validation
+- [x] T018 Run `go test ./...` ensuring new unit/integration/e2e tests fail before implementation, then pass after implementation
+- [x] T019 Execute resolver benchmark and record results to confirm <200ms load target
+- [x] T020 Capture CLI summary output screenshots or logs demonstrating YAML summary and override messaging; store under `docs/examples/config/`
+- [x] T021 Add or update operator runbook section in `docs/runbooks/declarative-config.md`
+
+## Phase 3.5: Polish
+- [x] T022 [P] Update CLI documentation (`docs/cli/commands.md`, `README.md`) with `--config` usage and discovery order
+- [x] T023 [P] Provide sample YAML configuration under `examples/config/chainctl.yaml`
+- [x] T024 [P] Add changelog entry in `CHANGELOG.md` describing declarative config support
+- [x] T025 Final verification: run `gofmt`, `gofumpt`, `golangci-lint`, and full `go test ./...`; attach artifacts to PR
+
+## Parallel Execution Guidance
+- Initial test authoring can run concurrently: T006, T008, T009 target different packages.
+- After core implementation, documentation tasks T022–T024 may proceed in parallel once CLI behavior is frozen.
+
+## Dependencies
+- Setup (T001–T003) precedes all other work.
+- Tests (T004–T010) must exist and fail before implementing T011–T017.
+- Implementation T011–T017 must complete before validation tasks T018–T021.
+- Documentation polish T022–T024 depends on final CLI UX (post T015/T020).
+- Final verification T025 runs last.

--- a/test/e2e/declarative_config_workflow_test.go
+++ b/test/e2e/declarative_config_workflow_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeclarativeConfigClusterInstallDryRun(t *testing.T) {
+	if os.Getenv("CHAINCTL_E2E") == "" {
+		t.Skip("skip declarative config e2e: set CHAINCTL_E2E=1 and provide KIND_KUBECONFIG")
+	}
+	if os.Getenv("CHAINCTL_E2E_SUDO") != "1" {
+		t.Skip("skip declarative config e2e: set CHAINCTL_E2E_SUDO=1 to permit sudo execution")
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "chainctl.yaml")
+
+	valuesFile := envOrDefault("CHAINCTL_VALUES_FILE", "test/e2e/testdata/values.enc")
+	namespace := envOrDefault("CHAINCTL_NAMESPACE", "demo")
+
+	configBody := []byte(`defaults:
+  namespace: ` + namespace + `
+  values-file: "` + valuesFile + `"
+commands:
+  chainctl cluster install:
+    flags:
+      bootstrap: true
+      dry-run: true
+      output: json
+`)
+
+	if err := os.WriteFile(configPath, configBody, 0o600); err != nil {
+		t.Fatalf("write declarative config: %v", err)
+	}
+
+	args := []string{
+		"run", "./cmd/chainctl", "cluster", "install",
+		"--config", configPath,
+		"--values-passphrase", envOrDefault("CHAINCTL_VALUES_PASSPHRASE", "secret"),
+	}
+
+	cmd := goCommand(t, projectRoot(t), []string{"GO111MODULE=on"}, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("declarative config cluster install dry-run failed: %v\n%s", err, string(out))
+	}
+}

--- a/test/integration/declarative_config_test.go
+++ b/test/integration/declarative_config_test.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dobrovols/chainctl/internal/cli"
+	internalconfig "github.com/dobrovols/chainctl/internal/config"
+	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
+)
+
+func TestDeclarativeConfigPipelineResolvesProfilesAndPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "chainctl.yaml")
+	valuesPath := filepath.Join(tmpDir, "values.enc")
+	if err := os.WriteFile(valuesPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatalf("write values file: %v", err)
+	}
+
+	writeYAML(t, configPath, `
+metadata:
+  name: declarative-demo
+defaults:
+  namespace: demo
+  values-file: "`+valuesPath+`"
+profiles:
+  staging:
+    namespace: staging
+commands:
+  chainctl cluster install:
+    flags:
+      dry-run: true
+      output: text
+  chainctl app install:
+    profiles:
+      - staging
+    flags:
+      chart: oci://registry.example.com/app/demo:1.0.0
+      release-name: demo-staging
+`)
+
+	t.Setenv("CHAINCTL_CONFIG", configPath)
+
+	root := cli.NewRootCommand()
+	catalog := internalconfig.NewCobraCatalog(root)
+	located, err := internalconfig.LocateConfig("")
+	if err != nil {
+		t.Fatalf("LocateConfig: %v", err)
+	}
+
+	loader := internalconfig.NewLoader(catalog)
+	profile, err := loader.Load(located.Path)
+	if err != nil {
+		t.Fatalf("Load profile: %v", err)
+	}
+
+	clusterRuntime := pkgconfig.FlagSet{
+		"namespace":         {Value: "runtime-ns", Source: pkgconfig.ValueSourceRuntime},
+		"values-passphrase": {Value: "runtime-pass", Source: pkgconfig.ValueSourceRuntime},
+		"output":            {Value: "json", Source: pkgconfig.ValueSourceRuntime},
+	}
+
+	clusterResolved, err := pkgconfig.ResolveInvocation(profile, "chainctl cluster install", clusterRuntime)
+	if err != nil {
+		t.Fatalf("ResolveInvocation(cluster install): %v", err)
+	}
+	if clusterResolved.Flags["namespace"].Value != "runtime-ns" {
+		t.Fatalf("expected runtime namespace override, got %v", clusterResolved.Flags["namespace"].Value)
+	}
+	if clusterResolved.Flags["values-file"].Source != pkgconfig.ValueSourceDefault {
+		t.Fatalf("expected values-file to come from defaults, got %s", clusterResolved.Flags["values-file"].Source)
+	}
+
+	textSummary, err := pkgconfig.FormatSummary(clusterResolved, pkgconfig.SummaryFormatText)
+	if err != nil {
+		t.Fatalf("FormatSummary(text): %v", err)
+	}
+	if !strings.Contains(textSummary, "runtime-ns") || !strings.Contains(textSummary, "values-file") {
+		t.Fatalf("expected summary to include runtime namespace and values-file, got:\n%s", textSummary)
+	}
+
+	jsonSummary, err := pkgconfig.FormatSummary(clusterResolved, pkgconfig.SummaryFormatJSON)
+	if err != nil {
+		t.Fatalf("FormatSummary(json): %v", err)
+	}
+	var summaryPayload map[string]any
+	if err := json.Unmarshal([]byte(jsonSummary), &summaryPayload); err != nil {
+		t.Fatalf("unmarshal summary json: %v", err)
+	}
+	if summaryPayload["commandPath"] != "chainctl cluster install" {
+		t.Fatalf("expected commandPath field, got %v", summaryPayload["commandPath"])
+	}
+
+	appResolved, err := pkgconfig.ResolveInvocation(profile, "chainctl app install", nil)
+	if err != nil {
+		t.Fatalf("ResolveInvocation(app install): %v", err)
+	}
+	if appResolved.Flags["namespace"].Value != "staging" {
+		t.Fatalf("expected staging namespace from profile, got %v", appResolved.Flags["namespace"].Value)
+	}
+	if appResolved.Flags["chart"].Source != pkgconfig.ValueSourceCommand {
+		t.Fatalf("expected chart to use command source, got %s", appResolved.Flags["chart"].Source)
+	}
+}
+
+func writeYAML(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/test/integration/declarative_config_test.go
+++ b/test/integration/declarative_config_test.go
@@ -12,6 +12,11 @@ import (
 	pkgconfig "github.com/dobrovols/chainctl/pkg/config"
 )
 
+const (
+	sampleNamespace     = "runtime-ns"
+	sampleValuesFileKey = "values-file"
+)
+
 func TestDeclarativeConfigPipelineResolvesProfilesAndPrecedence(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "chainctl.yaml")
@@ -58,7 +63,7 @@ commands:
 	}
 
 	clusterRuntime := pkgconfig.FlagSet{
-		"namespace":         {Value: "runtime-ns", Source: pkgconfig.ValueSourceRuntime},
+		"namespace":         {Value: sampleNamespace, Source: pkgconfig.ValueSourceRuntime},
 		"values-passphrase": {Value: "runtime-pass", Source: pkgconfig.ValueSourceRuntime},
 		"output":            {Value: "json", Source: pkgconfig.ValueSourceRuntime},
 	}
@@ -67,7 +72,7 @@ commands:
 	if err != nil {
 		t.Fatalf("ResolveInvocation(cluster install): %v", err)
 	}
-	if clusterResolved.Flags["namespace"].Value != "runtime-ns" {
+	if clusterResolved.Flags["namespace"].Value != sampleNamespace {
 		t.Fatalf("expected runtime namespace override, got %v", clusterResolved.Flags["namespace"].Value)
 	}
 	if clusterResolved.Flags["values-file"].Source != pkgconfig.ValueSourceDefault {
@@ -78,7 +83,7 @@ commands:
 	if err != nil {
 		t.Fatalf("FormatSummary(text): %v", err)
 	}
-	if !strings.Contains(textSummary, "runtime-ns") || !strings.Contains(textSummary, "values-file") {
+	if !strings.Contains(textSummary, sampleNamespace) || !strings.Contains(textSummary, sampleValuesFileKey) {
 		t.Fatalf("expected summary to include runtime namespace and values-file, got:\n%s", textSummary)
 	}
 


### PR DESCRIPTION
- Added declarative configuration plumbing: file discovery, validation, profile resolution, CLI wiring (--config), telemetry emission, and summary output.

- Documented the workflow with new spec artifacts, CLI docs, runbook, and reference examples for YAML plus generated summaries.

- Expanded automated coverage with unit, integration, e2e tests and benchmarks to ensure resolver precedence and binder behavior (coverage for cmd/chainctl/declarative now 82.4%).